### PR TITLE
feature/WPS-6824-backend-setting-design-change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ script/
 *.o
 *.so
 *.codex
+*.claude
 
 # ignore packaged files
 *.7z
@@ -24,3 +25,4 @@ script/
 *.rar
 *.tar
 *.zip
+*.md

--- a/admin/class-mwb-bookings-for-woocommerce-admin.php
+++ b/admin/class-mwb-bookings-for-woocommerce-admin.php
@@ -69,8 +69,8 @@ class Mwb_Bookings_For_Woocommerce_Admin {
 
 		$mwb_bfw_taxonomy_array = $this->mwb_get_taxonomy_array();
 		global $post_type;
-
 		$mbfw_is_plugin_page = ( ( isset( $screen->id ) && ( ( 'wp-swings_page_mwb_bookings_for_woocommerce_menu' === $screen->id ) || ( 'wp-swings_page_home' === $screen->id ) ) ) || ( in_array( get_current_screen()->taxonomy, $mwb_bfw_taxonomy_array ) ) );
+// var_dump($screen->id,$mbfw_is_plugin_page);die;
 
 		if ( $mbfw_is_plugin_page ) {
 
@@ -81,7 +81,7 @@ class Mwb_Bookings_For_Woocommerce_Admin {
 			wp_enqueue_style( 'mwb-mbfw-meterial-lite', MWB_BOOKINGS_FOR_WOOCOMMERCE_DIR_URL . 'package/lib/material-design/material-lite.min.css', array(), $this->version, 'all' );
 
 			wp_enqueue_style( 'mwb-mbfw-meterial-icons-css', MWB_BOOKINGS_FOR_WOOCOMMERCE_DIR_URL . 'package/lib/material-design/icon.css', array(), $this->version, 'all' );
-			wp_enqueue_style( 'mwb-mbfw-admin-min-css', MWB_BOOKINGS_FOR_WOOCOMMERCE_DIR_URL . 'admin/css/mwb-admin.min.css', array(), $this->version, 'all' );
+			wp_enqueue_style( 'mwb-mbfw-admin-min-css', MWB_BOOKINGS_FOR_WOOCOMMERCE_DIR_URL . 'admin/css/mwb-admin.css', array(), filemtime( MWB_BOOKINGS_FOR_WOOCOMMERCE_DIR_PATH . 'admin/css/mwb-admin.css' ), 'all' );
 			wp_enqueue_style( 'mwb-datatable-css', MWB_BOOKINGS_FOR_WOOCOMMERCE_DIR_URL . 'package/lib/datatables/media/css/jquery.dataTables.min.css', array(), $this->version, 'all' );
 			wp_enqueue_style( 'mwb-admin-full-calendar-css', MWB_BOOKINGS_FOR_WOOCOMMERCE_DIR_URL . 'package/lib/full-calendar/main.css', array(), $this->version, 'all' );
 			wp_enqueue_style( 'wps-admin-boo-home-css', MWB_BOOKINGS_FOR_WOOCOMMERCE_DIR_URL . 'admin/css/wps-admin-boo-home.min.css', array(), $this->version, 'all' );
@@ -124,7 +124,7 @@ class Mwb_Bookings_For_Woocommerce_Admin {
 			wp_enqueue_script( 'mwb-mbfw-datatable', MWB_BOOKINGS_FOR_WOOCOMMERCE_DIR_URL . 'package/lib/datatables.net/js/jquery.dataTables.min.js', array(), $this->version, true );
 			wp_enqueue_script( 'mwb-mbfw-datatable-btn', MWB_BOOKINGS_FOR_WOOCOMMERCE_DIR_URL . 'package/lib/datatables.net/buttons/dataTables.buttons.min.js', array(), $this->version, true );
 			wp_enqueue_script( 'mwb-mbfw-datatable-btn-2', MWB_BOOKINGS_FOR_WOOCOMMERCE_DIR_URL . 'package/lib/datatables.net/buttons/buttons.html5.min.js', array(), $this->version, true );
-			wp_register_script( $this->plugin_name . 'admin-js', MWB_BOOKINGS_FOR_WOOCOMMERCE_DIR_URL . 'admin/js/mwb-bookings-for-woocommerce-admin.js', array( 'jquery', 'mwb-mbfw-select2', 'mwb-mbfw-metarial-js', 'mwb-mbfw-metarial-js2', 'mwb-mbfw-metarial-lite' ), $this->version, true );
+			wp_register_script( $this->plugin_name . 'admin-js', MWB_BOOKINGS_FOR_WOOCOMMERCE_DIR_URL . 'admin/js/mwb-bookings-for-woocommerce-admin.js', array( 'jquery', 'mwb-mbfw-select2', 'mwb-mbfw-metarial-js', 'mwb-mbfw-metarial-js2', 'mwb-mbfw-metarial-lite' ), filemtime( MWB_BOOKINGS_FOR_WOOCOMMERCE_DIR_PATH . 'admin/js/mwb-bookings-for-woocommerce-admin.js' ), true );
 			wp_localize_script(
 				$this->plugin_name . 'admin-js',
 				'mbfw_admin_param',
@@ -132,6 +132,7 @@ class Mwb_Bookings_For_Woocommerce_Admin {
 					'todays_date'               => current_time( 'Y-m-d' ),
 					'ajaxurl'                   => admin_url( 'admin-ajax.php' ),
 					'nonce'                     => wp_create_nonce( 'mwb_mbfw_admin_nonce' ),
+					'talk_to_expert_nonce'      => wp_create_nonce( 'mwb_mbfw_talk_to_expert_nonce' ),
 					'reloadurl'                 => admin_url( 'admin.php?page=mwb_bookings_for_woocommerce_menu' ),
 					'mbfw_gen_tab_enable'       => get_option( 'mbfw_radio_switch_demo' ),
 					'mbfw_admin_param_location' => ( admin_url( 'admin.php' ) . '?page=mwb_bookings_for_woocommerce_menu&mbfw_tab=mwb-bookings-for-woocommerce-general' ),
@@ -587,7 +588,7 @@ class Mwb_Bookings_For_Woocommerce_Admin {
 				'title'       => __( 'Daily Start Time', 'mwb-bookings-for-woocommerce' ),
 				'id'          => 'mwb_mbfw_daily_start_time',
 				'name'        => 'mwb_mbfw_daily_start_time',
-				'class'       => 'mwb_mbfw_daily_start_time mbfw_time_picker',
+				'class'       => 'mwb_mbfw_daily_start_time mbfw_time_picker wps-daily-time-pill',
 				'value'       => get_option( 'mwb_mbfw_daily_start_time' ),
 				'type'        => 'time',
 				'description' => __( 'Please choose daily start time, users will be able to book from this time.', 'mwb-bookings-for-woocommerce' ),
@@ -596,7 +597,7 @@ class Mwb_Bookings_For_Woocommerce_Admin {
 				'title'       => __( 'Daily End Time', 'mwb-bookings-for-woocommerce' ),
 				'id'          => 'mwb_mbfw_daily_end_time',
 				'name'        => 'mwb_mbfw_daily_end_time',
-				'class'       => 'mwb_mbfw_daily_end_time mbfw_time_picker',
+				'class'       => 'mwb_mbfw_daily_end_time mbfw_time_picker wps-daily-time-pill',
 				'value'       => get_option( 'mwb_mbfw_daily_end_time' ),
 				'type'        => 'time',
 				'description' => __( 'Please choose daily end time, bookings will be closed for users after this time.', 'mwb-bookings-for-woocommerce' ),

--- a/admin/css/mwb-admin.css
+++ b/admin/css/mwb-admin.css
@@ -156,16 +156,17 @@ select {
 
 .mwb-link.active {
   position: relative;
-  color: #2196f3 !important;
+  color: #111111 !important;
+  font-family: "NunitoSans-Bold";
 }
 
-.mwb-link:after {
+.mwb-link.active:after {
   content: "";
   position: absolute;
   bottom: 0;
   left: 0;
   right: 0;
-  border-bottom: 3px solid #2196f3;
+  border-bottom: 3px solid #f5a623;
   border-radius: 2px;
 }
 
@@ -184,41 +185,94 @@ select {
 
 .mwb-section {
   padding: 28px 32px;
+  background-color: #f5f6fa;
+  border-radius: 0 0 8px 8px;
 }
 
 .mwb-header-container {
-  padding: 28px 32px;
+  padding: 10px 24px;
   display: flex;
   flex-wrap: wrap;
   align-items: center;
   justify-content: space-between;
   margin-top: 15px;
-  margin-bottom: 8px;
+  margin-bottom: 0;
   margin-right: 15px;
+  background: #1e1245;
+  border-radius: 8px 8px 0 0;
+}
+
+.mwb-header-container .mwb-header-branding {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.mwb-header-container .mwb-header-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 30px;
+  padding: 5px 14px;
+  border: 1px solid rgba(255, 255, 255, 0.30);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.10);
+  color: #ffffff;
+  font-family: "NunitoSans-Bold";
+  font-size: 12px;
+  line-height: 1;
+  letter-spacing: 0.6px;
+  text-transform: uppercase;
 }
 
 .mwb-header-container .mwb-header-title {
-  font-family: "NunitoSans-ExtraBold";
+  font-family: "NunitoSans-SemiBold";
   font-style: normal;
-  font-weight: 800;
-  font-size: 20px;
-  line-height: 24px;
-  letter-spacing: 0.3px;
-  color: #2196f3;
-  flex: 0 0 100%;
-  max-width: calc(100% - 200px);
+  font-weight: 600;
+  font-size: 15px;
+  line-height: 1.4;
+  letter-spacing: 0.2px;
+  color: #ffffff;
+  flex: 0 0 auto;
+  max-width: 100%;
+  text-transform: none;
+}
+
+.mwb-header-container .mwb-link {
+  color: rgba(255, 255, 255, 0.75);
+  font-size: 13px;
+}
+
+.mwb-header-container .mwb-link:hover {
+  color: #ffffff !important;
+}
+
+.mwb-header-container span {
+  color: rgba(255, 255, 255, 0.4);
+  margin: 0 6px;
+}
+
+.mwb-bg-white.mwb-r-8 {
+  border-radius: 8px;
+  overflow: hidden;
 }
 
 .mwb-form-group {
   display: flex;
   flex-wrap: wrap;
-  margin: 0 -15px 35px;
+  align-items: center;
+  margin: 0 0 8px 0;
+  background: #ffffff;
+  border: 1px solid #e8e8f0;
+  border-radius: 8px;
+  padding: 16px 20px;
 }
 
 .mwb-form-group .mwb-form-group__label {
-  flex: 0 0 100%;
-  max-width: 200px;
-  padding: 0 15px;
+  flex: 0 0 220px;
+  max-width: 220px;
+  padding: 0;
 }
 
 .mwb-form-group .mwb-form-group__label .mwb-form-label {
@@ -229,9 +283,70 @@ select {
 }
 
 .mwb-form-group .mwb-form-group__control {
-  flex: 0 0 100%;
-  max-width: calc(100% - 200px);
-  padding: 0 15px;
+  flex: 1;
+  max-width: calc(100% - 220px);
+  padding: 0 0 0 16px;
+}
+
+/* Color input redesign */
+.mwb-color-input-wrap {
+  display: flex;
+  align-items: flex-start;
+  gap: 14px;
+  border: 1px solid #e0d5b8;
+  border-radius: 10px;
+  padding: 12px 16px;
+  background: #fdfbf5;
+  max-width: 520px;
+}
+
+.mwb-color-swatch-input {
+  width: 48px;
+  height: 48px;
+  border-radius: 8px;
+  flex-shrink: 0;
+  cursor: pointer;
+  border: none;
+  padding: 2px;
+  background: transparent;
+}
+
+.mwb-color-input-details {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  justify-content: center;
+}
+
+.mwb-color-input-top-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.mwb-color-badge {
+  background: #f2e8d0;
+  color: #8c7449;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.6px;
+  padding: 3px 11px;
+  border-radius: 20px;
+  border: 1px solid #ddd0b0;
+  text-transform: uppercase;
+}
+
+.mwb-color-hex-display {
+  font-size: 16px;
+  font-weight: 700;
+  color: #111111;
+  font-family: "NunitoSans-Bold", monospace;
+}
+
+.mwb-color-input-description {
+  font-size: 13px;
+  color: #888888;
+  font-family: "NunitoSans-Regular", sans-serif;
 }
 
 .mwb-form-group .mwb-form-group__control .mwb-form-select:hover select {
@@ -250,9 +365,892 @@ select {
   padding-left: 16px;
 }
 
+/* =============================================
+   Inline field layout (control + description)
+   ============================================= */
+.wps-field-inline {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  flex-wrap: wrap;
+}
+
+/* Checkbox inline description — dark purple */
+.wps-field-inline .wps-checkbox + .wps-helper-text {
+  color: #2d1b5e;
+  font-size: 14px;
+  font-family: "NunitoSans-Regular", sans-serif;
+}
+
+/* Compensate for halo padding so checkbox aligns with text */
+.wps-field-inline .wps-checkbox {
+  margin: -8px;
+}
+
+/* =============================================
+   Pure CSS Toggle — amber/orange style
+   ============================================= */
+.wps-toggle {
+  position: relative;
+  display: inline-block;
+  width: 54px;
+  height: 30px;
+  flex-shrink: 0;
+  cursor: pointer;
+}
+
+.wps-toggle__input {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.wps-toggle__slider {
+  position: absolute;
+  inset: 0;
+  background-color: #e5e7eb;
+  border: 2px solid #d1d5db;
+  border-radius: 15px;
+  transition: background-color 0.25s ease, border-color 0.25s ease;
+  cursor: pointer;
+}
+
+.wps-toggle__slider::before {
+  content: "";
+  position: absolute;
+  width: 22px;
+  height: 22px;
+  left: 2px;
+  top: 2px;
+  background-color: #9ca3af;
+  border-radius: 50%;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.2);
+  transition: transform 0.25s ease, background-color 0.25s ease;
+}
+
+.wps-toggle__input:checked + .wps-toggle__slider {
+  background-color: #fef3c7;
+  border-color: #f5a623;
+}
+
+.wps-toggle__input:checked + .wps-toggle__slider::before {
+  background-color: #f5a623;
+  transform: translateX(24px);
+}
+
+/* =============================================
+   Pure CSS Checkbox — orange with blue halo
+   ============================================= */
+.wps-checkbox {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background-color: transparent;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: background-color 0.2s;
+}
+
+/* Blue halo when checked
+.wps-checkbox:has(.wps-checkbox__input:checked) {
+  background-color: #dbeafe;
+} */
+
+.wps-checkbox__input {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.wps-checkbox__box {
+  width: 22px;
+  height: 22px;
+  border: 2px solid #d1d5db;
+  border-radius: 6px;
+  background-color: #ffffff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  position: relative;
+  z-index: 1;
+  transition: border-color 0.2s, background-color 0.2s;
+}
+
+.wps-checkbox__input:checked + .wps-checkbox__box {
+  background-color: #f5a623;
+  border-color: #f5a623;
+}
+
+.wps-checkbox__input:checked + .wps-checkbox__box::after {
+  content: "";
+  display: block;
+  width: 5px;
+  height: 10px;
+  border: 2px solid #ffffff;
+  border-top: none;
+  border-left: none;
+  transform: rotate(45deg) translateY(-2px);
+}
+
+/* =============================================
+   Plain text input
+   ============================================= */
+.wps-text-input {
+  min-height: 54px;
+  width: min(100%, 360px);
+  flex: 0 1 360px;
+  border: 2px solid #d1d5db;
+  border-radius: 999px;
+  padding: 12px 22px;
+  font-size: 18px;
+  line-height: 1.35;
+  color: #32126d;
+  background: #ffffff;
+  font-family: "NunitoSans-Regular", sans-serif;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  outline: none;
+  box-shadow: none;
+}
+
+.wps-text-input:focus {
+  border-color: #9ca3af;
+  box-shadow: none;
+}
+
+.wps-text-input::placeholder {
+  color: #32126d;
+}
+
+.wps-time-row {
+  gap: 18px;
+}
+
+.wps-time-input {
+  min-height: 54px;
+  width: min(100%, 360px);
+  flex: 0 1 360px;
+  border: 2px solid #d1d5db;
+  border-radius: 999px;
+  padding: 12px 22px;
+  font-size: 18px;
+  line-height: 1.35;
+  color: #32126d;
+  background: #ffffff;
+  font-family: "NunitoSans-Regular", sans-serif;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  outline: none;
+  box-shadow: none;
+}
+
+.wps-time-input:focus {
+  border-color: #9ca3af;
+  box-shadow: none;
+}
+
+.wps-time-description {
+  flex: 1 1 260px;
+  color: #32126d !important;
+  font-size: 16px;
+  line-height: 1.5;
+}
+
+.wps-time-input.wps-daily-time-pill {
+  min-height: 54px;
+  width: min(100%, 360px);
+  flex: 0 1 360px;
+  border: 2px solid #d1d5db;
+  border-radius: 999px;
+  padding: 12px 22px;
+  font-size: 18px;
+  line-height: 1.35;
+  color: #32126d;
+  background: #ffffff;
+  box-shadow: none;
+}
+
+.wps-time-input.wps-daily-time-pill:focus {
+  border-color: #9ca3af;
+  box-shadow: none;
+}
+
+/* =============================================
+   Availability Per-Day Time Pickers (Days grid)
+   ============================================= */
+
+.mbfw-avl-days-wrap {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px 24px;
+  width: 100%;
+}
+
+.mbfw-avl-days {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.mbfw-avl-days label.mwb-form-label {
+  flex: 0 0 80px;
+  font-family: "NunitoSans-SemiBold";
+  font-size: 14px;
+  color: #1f1f1f;
+}
+
+.mbfw-avl-days-time {
+  position: relative;
+  flex: 1;
+  min-width: 0;
+}
+
+.mbfw-avl-days-time input.mbfw_time_picker,
+.mwb_bfw_config_tab .mbfw-avl-days-time input.mbfw_time_picker {
+  display: block !important;
+  width: 100% !important;
+  box-sizing: border-box !important;
+  min-height: 48px !important;
+  border: 2px solid #d1d5db !important;
+  border-radius: 999px !important;
+  padding: 10px 44px 10px 20px !important;
+  font-size: 15px !important;
+  line-height: 1.35 !important;
+  color: #32126d !important;
+  background-color: #ffffff !important;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%233b82f6' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='12' cy='12' r='10'/%3E%3Cpolyline points='12 6 12 12 16 14'/%3E%3C/svg%3E") !important;
+  background-repeat: no-repeat !important;
+  background-position: right 14px center !important;
+  background-size: 18px 18px !important;
+  font-family: "NunitoSans-Regular", sans-serif !important;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease !important;
+  outline: none !important;
+  box-shadow: none !important;
+}
+
+.mbfw-avl-days-time input.mbfw_time_picker:focus,
+.mwb_bfw_config_tab .mbfw-avl-days-time input.mbfw_time_picker:focus {
+  border-color: #9ca3af !important;
+  box-shadow: none !important;
+}
+
+/* Hide the external clock span — clock is now a background SVG on the input */
+.mbfw-avl-days-time .dashicons-clock {
+  display: none !important;
+}
+
+@media (max-width: 900px) {
+  .mbfw-avl-days-wrap {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* =============================================
+   Select dropdown — bordered field with inline help text
+   ============================================= */
+.wps-select-wrap {
+  position: relative;
+  width: min(100%, 480px);
+  flex: 0 1 480px;
+}
+
+.wps-select-wrap::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  right: 18px;
+  width: 10px;
+  height: 10px;
+  border-right: 2px solid #9a9a9a;
+  border-bottom: 2px solid #9a9a9a;
+  transform: translateY(-65%) rotate(45deg);
+  pointer-events: none;
+}
+
+.wps-select-wrap--multiple::after {
+  display: none;
+}
+
+.wps-select {
+  width: 100%;
+  min-height: 54px;
+  border: 2px solid #d1d5db;
+  border-radius: 999px;
+  padding: 12px 46px 12px 22px !important;
+  font-size: 18px;
+  line-height: 1.35;
+  color: #32126d;
+  background-color: #ffffff;
+  font-family: "NunitoSans-Regular", sans-serif;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-image: none;
+  cursor: pointer;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  outline: none;
+  box-shadow: none;
+}
+
+.wps-select:focus {
+  border-color: #9ca3af;
+  box-shadow: none;
+}
+
+.wps-select:hover {
+  border-color: #9ca3af;
+}
+
+.wps-select option {
+  color: #32126d;
+  font-family: "NunitoSans-Regular", sans-serif;
+}
+
+.wps-select--multiple {
+  min-height: 140px;
+  padding: 14px 16px !important;
+}
+
+/* Select description text — purple, inline */
+.wps-select-description {
+  flex: 1 1 260px;
+  color: #32126d !important;
+  font-size: 16px;
+  line-height: 1.5;
+}
+
+.wps-select-wrap .select2-container,
+.mwb-form-group__control > .select2-container {
+  width: min(100%, 480px) !important;
+  max-width: 100%;
+  flex: 0 1 480px;
+}
+
+.wps-select-wrap--multiple .select2-container,
+.mwb-defaut-multiselect + .select2-container,
+#mwb_bfwp_order_statuses_to_cancel + .select2-container {
+  width: min(100%, 480px) !important;
+}
+
+.select2-container--default .select2-selection--single,
+.select2-container--default .select2-selection--multiple {
+  min-height: 54px;
+  border: 2px solid #d1d5db !important;
+  border-radius: 999px !important;
+  background: #ffffff !important;
+  box-shadow: none !important;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.select2-container--default.select2-container--focus .select2-selection--single,
+.select2-container--default.select2-container--focus .select2-selection--multiple,
+.select2-container--default.select2-container--open .select2-selection--single,
+.select2-container--default.select2-container--open .select2-selection--multiple {
+  border-color: #9ca3af !important;
+  box-shadow: none !important;
+}
+
+.select2-container--default .select2-selection--single:hover,
+.select2-container--default .select2-selection--multiple:hover {
+  border-color: #9ca3af !important;
+}
+
+.select2-container--default .select2-selection--single .select2-selection__rendered {
+  padding: 12px 46px 12px 22px;
+  color: #32126d !important;
+  font-family: "NunitoSans-Regular", sans-serif;
+  font-size: 18px;
+  line-height: 1.35;
+}
+
+.select2-container--default .select2-selection--single .select2-selection__arrow {
+  height: 100%;
+  width: 42px;
+  right: 0;
+}
+
+.select2-container--default .select2-selection--single .select2-selection__arrow b {
+  border: none;
+  width: 10px;
+  height: 10px;
+  margin: -7px 0 0 -5px;
+  border-right: 2px solid #9a9a9a;
+  border-bottom: 2px solid #9a9a9a;
+  transform: rotate(45deg);
+}
+
+.select2-container--default .select2-selection--multiple {
+  padding: 8px 12px;
+}
+
+.select2-container--default .select2-selection--multiple .select2-selection__rendered {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 0;
+  white-space: normal;
+}
+
+.select2-container--default .select2-selection--multiple .select2-selection__choice {
+  margin: 0 !important;
+  padding: 6px 10px 6px 24px !important;
+  border: 1px solid #d8cff6 !important;
+  border-radius: 999px !important;
+  background: #f6f2ff !important;
+  color: #32126d !important;
+  font-size: 14px;
+}
+
+.select2-container--default .select2-selection--multiple .select2-selection__choice__remove {
+  left: 8px !important;
+  right: auto !important;
+  top: 50%;
+  margin-top: -9px;
+  border: none !important;
+  color: #7b61c8 !important;
+  font-size: 16px;
+}
+
+.select2-container--default .select2-search--inline .select2-search__field {
+  min-height: 32px;
+  margin-top: 0 !important;
+  font-size: 16px;
+  font-family: "NunitoSans-Regular", sans-serif;
+}
+
+.select2-dropdown {
+  border: 1px solid #d8cff6 !important;
+  border-radius: 10px !important;
+  overflow: hidden;
+  box-shadow: 0 10px 24px rgba(50, 18, 109, 0.12);
+}
+
+.select2-results__option {
+  padding: 10px 14px;
+  font-size: 15px;
+  color: #303030;
+}
+
+.select2-container--default .select2-results__option--highlighted[aria-selected],
+.select2-container--default .select2-results__option--highlighted[data-selected] {
+  background: #f6f2ff !important;
+  color: #32126d !important;
+}
+
+.select2-container--default .select2-results__option[aria-selected=true],
+.select2-container--default .select2-results__option[data-selected=true] {
+  background: #ede7ff !important;
+  color: #32126d !important;
+}
+
+.wps_order_status_.wps-calendar-filter-select {
+  min-height: 40px;
+  /* min-width: 420px; */
+  border: 2px solid #d1d5db !important;
+  border-radius: 999px !important;
+  padding: 10px 56px 10px 26px !important;
+  font-size: 16px !important;
+  line-height: 1.2;
+  color: #32126d !important;
+  background-color: #ffffff !important;
+  background-image: linear-gradient(45deg, transparent 50%, #9f9f9f 50%), linear-gradient(135deg, #9f9f9f 50%, transparent 50%) !important;
+  background-position: calc(100% - 28px) calc(50% - 4px), calc(100% - 18px) calc(50% - 4px) !important;
+  background-size: 10px 10px, 10px 10px !important;
+  background-repeat: no-repeat !important;
+  box-shadow: none;
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+}
+
+.wps_order_status_.wps-calendar-filter-select:focus {
+  border-color: #9ca3af !important;
+  box-shadow: none !important;
+  outline: none !important;
+}
+
+.wps-calendar-action-btn.button {
+  min-width: 154px;
+  min-height: 40px;
+  padding: 10px 26px !important;
+  border: 0 !important;
+  border-radius: 999px !important;
+  font-family: "NunitoSans-ExtraBold", sans-serif !important;
+  font-size: 18px !important;
+  line-height: 1.1;
+  letter-spacing: 0.6px;
+  text-shadow: none;
+}
+
+.wps-calendar-action-btn--primary.button {
+  background: #171a33 !important;
+  color: #ffffff !important;
+  box-shadow: 0 12px 24px rgba(23, 26, 51, 0.16);
+}
+
+.wps-calendar-action-btn--primary.button:hover,
+.wps-calendar-action-btn--primary.button:focus {
+  background: #111429 !important;
+  color: #ffffff !important;
+}
+
+.wps-calendar-action-btn--secondary.button {
+  background: #ffffff !important;
+  color: #32126d !important;
+  border: 2px solid #e8cdfd !important;
+  box-shadow: 0 0 0 6px rgba(232, 205, 253, 0.22);
+}
+
+.wps-calendar-action-btn--secondary.button:hover,
+.wps-calendar-action-btn--secondary.button:focus {
+  background: #faf5ff !important;
+  color: #32126d !important;
+}
+
+/* =============================================
+   Tab Highlight Block
+   ============================================= */
+.wps-tab-highlight-block {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  background: #f7f7f7;
+  border: 1px solid #e8cdfd;
+  border-radius: 12px;
+  padding: 24px 28px;
+  margin-bottom: 16px;
+}
+
+.wps-tab-highlight-block__left {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  flex: 1;
+}
+
+.wps-tab-highlight-block__category {
+  font-family: "NunitoSans-Bold", sans-serif;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 1.2px;
+  color: #f5a623;
+  text-transform: uppercase;
+}
+
+.wps-tab-highlight-block__title {
+  font-family: "NunitoSans-ExtraBold", sans-serif;
+  font-size: 26px;
+  font-weight: 800;
+  color: #171a33;
+  margin: 0;
+  padding: 0;
+  line-height: 1.2;
+}
+
+.wps-tab-highlight-block__desc {
+  font-family: "NunitoSans-Regular", sans-serif;
+  font-size: 14px;
+  color: #6b7280;
+  margin: 0;
+  max-width: 560px;
+  line-height: 1.6;
+}
+
+.wps-tab-highlight-block__btn {
+  display: inline-block;
+  background: #171a33;
+  color: #ffffff !important;
+  font-family: "NunitoSans-Bold", sans-serif;
+  font-size: 14px;
+  font-weight: 700;
+  border-radius: 999px;
+  padding: 12px 24px;
+  text-decoration: none !important;
+  white-space: nowrap;
+  flex-shrink: 0;
+  transition: background-color 0.2s;
+}
+
+.wps-tab-highlight-block__btn:hover {
+  background: #2d3458;
+  color: #ffffff !important;
+}
+
+/* =============================================
+   Helper / description text
+   ============================================= */
+.wps-helper-text {
+  font-size: 13px;
+  color: #6b7280;
+  font-family: "NunitoSans-Regular", sans-serif;
+  line-height: 1.5;
+}
+
+/* Toggle-specific: stack control + description vertically */
+.wps-toggle-wrap {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 8px;
+}
+
+.wps-toggle-wrap .wps-helper-text {
+  font-size: 14px;
+  color: #2d1b5e;
+  font-family: "NunitoSans-Regular", sans-serif;
+}
+
+/* Toggle wrapper alignment */
+.mwb-form-group .mwb-form-group__control > div:first-child:has(.mdc-switch) {
+  display: flex;
+  align-items: center;
+  min-height: 24px;
+}
+
+/* =============================================
+   iOS-style Toggle Switch Override
+   ============================================= */
+.mwb-form-group .mdc-switch {
+  position: relative;
+  display: inline-block;
+  width: 44px !important;
+  height: 24px !important;
+  min-width: 44px;
+  flex-shrink: 0;
+  cursor: pointer;
+}
+
+.mwb-form-group .mdc-switch .mdc-switch__track {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 44px !important;
+  height: 24px !important;
+  border-radius: 12px !important;
+  background-color: #d1d5db !important;
+  opacity: 1 !important;
+  border: none !important;
+  transition: background-color 0.22s ease !important;
+}
+
+.mwb-form-group .mdc-switch--checked .mdc-switch__track,
+.mwb-form-group .mdc-switch:has(.mdc-switch__native-control:checked) .mdc-switch__track {
+  background-color: #3b82f6 !important;
+}
+
+.mwb-form-group .mdc-switch .mdc-switch__thumb-underlay {
+  position: absolute !important;
+  top: 2px !important;
+  left: 2px !important;
+  width: 20px !important;
+  height: 20px !important;
+  transform: translateX(0) !important;
+  transition: transform 0.22s ease !important;
+}
+
+.mwb-form-group .mdc-switch--checked .mdc-switch__thumb-underlay,
+.mwb-form-group .mdc-switch:has(.mdc-switch__native-control:checked) .mdc-switch__thumb-underlay {
+  transform: translateX(20px) !important;
+}
+
+.mwb-form-group .mdc-switch .mdc-switch__thumb {
+  width: 20px !important;
+  height: 20px !important;
+  border-radius: 50% !important;
+  background-color: #ffffff !important;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.3) !important;
+  border: none !important;
+}
+
+.mwb-form-group .mdc-switch .mdc-switch__thumb-underlay::before,
+.mwb-form-group .mdc-switch .mdc-switch__thumb-underlay::after {
+  display: none !important;
+}
+
 .mwb-form-group .mwb-form-group__control .mdc-switch__native-control {
-  width: 68px;
-  height: 48px;
+  position: absolute !important;
+  top: 0 !important;
+  left: 0 !important;
+  width: 44px !important;
+  height: 24px !important;
+  opacity: 0 !important;
+  cursor: pointer !important;
+  margin: 0 !important;
+  z-index: 2;
+}
+
+/* =============================================
+   Clean Text / Number / Email Input Override
+   ============================================= */
+.mwb-form-group .mdc-text-field--outlined {
+  height: auto !important;
+  width: auto !important;
+  background: transparent !important;
+  padding: 0 !important;
+  display: block;
+}
+
+.mwb-form-group .mdc-text-field--outlined .mdc-notched-outline {
+  display: none !important;
+}
+
+.mwb-form-group .mdc-text-field--outlined .mdc-text-field__input {
+  height: 40px !important;
+  min-width: 280px;
+  border: 1px solid #bab7c1 !important;
+  border-radius: 12px !important;
+  padding: 8px 14px !important;
+  font-size: 14px !important;
+  color: #374151 !important;
+  background: #ffffff !important;
+  font-family: "NunitoSans-Regular", sans-serif !important;
+  transition: border-color 0.2s ease !important;
+  outline: none !important;
+  box-shadow: none !important;
+}
+
+.mwb-form-group .mdc-text-field--outlined .mdc-text-field__input:focus {
+  border-color: #3b82f6 !important;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1) !important;
+}
+
+.mwb-form-group .mdc-text-field--outlined .mdc-text-field__input::placeholder {
+  color: #9ca3af !important;
+}
+
+.mwb-form-group .mdc-text-field--outlined.mdc-text-field--textarea {
+  display: block;
+}
+
+.mwb-form-group .mdc-text-field--textarea .mdc-text-field__input {
+  height: auto !important;
+  min-height: 80px;
+}
+
+/* Helper / description text */
+.mwb-form-group .mdc-text-field-helper-line {
+  padding: 0 !important;
+  margin-top: 5px;
+}
+
+.mwb-form-group .mwb-helper-text {
+  font-size: 13px !important;
+  color: #6b7280 !important;
+  font-family: "NunitoSans-Regular", sans-serif !important;
+  padding: 0 !important;
+}
+
+/* =============================================
+   Clean Checkbox Override
+   ============================================= */
+.mwb-form-group .mdc-form-field {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.mwb-form-group .mdc-checkbox {
+  width: 18px !important;
+  height: 18px !important;
+  flex-shrink: 0;
+  position: relative;
+  padding: 0 !important;
+}
+
+.mwb-form-group .mdc-checkbox .mdc-checkbox__background {
+  width: 18px !important;
+  height: 18px !important;
+  top: 0 !important;
+  left: 0 !important;
+  border-radius: 4px !important;
+  border: 2px solid #d1d5db !important;
+  background-color: #ffffff !important;
+  transition: border-color 0.2s, background-color 0.2s !important;
+}
+
+.mwb-form-group .mdc-checkbox .mdc-checkbox__native-control:checked ~ .mdc-checkbox__background,
+.mwb-form-group .mdc-checkbox .mdc-checkbox__background[data-mdc-animation-ready] {
+  border-color: #3b82f6 !important;
+  background-color: #3b82f6 !important;
+}
+
+.mwb-form-group .mdc-checkbox .mdc-checkbox__checkmark {
+  color: #ffffff !important;
+  width: 100% !important;
+}
+
+.mwb-form-group .mdc-checkbox .mdc-checkbox__checkmark-path {
+  stroke: #ffffff !important;
+  stroke-width: 3px !important;
+}
+
+.mwb-form-group .mdc-checkbox .mdc-checkbox__mixedmark {
+  border-color: #ffffff !important;
+}
+
+.mwb-form-group .mdc-checkbox .mdc-checkbox__ripple,
+.mwb-form-group .mdc-checkbox::before,
+.mwb-form-group .mdc-checkbox::after {
+  display: none !important;
+}
+
+.mwb-form-group .mdc-checkbox .mdc-checkbox__native-control {
+  width: 18px !important;
+  height: 18px !important;
+  opacity: 0 !important;
+  position: absolute !important;
+  top: 0 !important;
+  left: 0 !important;
+  cursor: pointer !important;
+  margin: 0 !important;
+  z-index: 1;
+}
+
+.mwb-form-group .mdc-form-field label {
+  font-size: 13px !important;
+  color: #6b7280 !important;
+  cursor: pointer;
+  font-family: "NunitoSans-Regular", sans-serif !important;
+  margin: 0 !important;
+}
+
+/* =============================================
+   Clean Select Override
+   ============================================= */
+.mwb-form-group .mwb-form-select select {
+  height: 40px !important;
+  min-width: 280px;
+  border: 1px solid #d1d5db !important;
+  border-radius: 6px !important;
+  padding: 8px 36px 8px 14px !important;
+  font-size: 14px !important;
+  color: #374151 !important;
+  background-color: #ffffff !important;
+  font-family: "NunitoSans-Regular", sans-serif !important;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8'%3E%3Cpath d='M1 1l5 5 5-5' stroke='%236b7280' stroke-width='1.5' fill='none' stroke-linecap='round'/%3E%3C/svg%3E") !important;
+  background-repeat: no-repeat !important;
+  background-position: right 12px center !important;
+  cursor: pointer;
+  transition: border-color 0.2s ease !important;
+}
+
+.mwb-form-group .mwb-form-select select:focus {
+  border-color: #3b82f6 !important;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1) !important;
+  outline: none !important;
+}
+
+.mwb-form-group .mwb-form-select .mdl-textfield__label {
+  display: none !important;
 }
 
 .mwb-form-group .mwb-password-hidden {
@@ -291,9 +1289,28 @@ select {
 }
 
 .mdc-button {
-  border-radius: 35px !important;
-  padding: 12px 24px !important;
-  height: 100%;
+  background-color: #111827 !important;
+  color: #ffffff !important;
+  border: none !important;
+  border-radius: 999px !important;
+  padding: 12px 28px !important;
+  height: auto !important;
+  font-size: 14px !important;
+  font-weight: 700 !important;
+  letter-spacing: 0.3px !important;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18) !important;
+  cursor: pointer !important;
+  transition: background-color 0.2s, box-shadow 0.2s !important;
+}
+
+.mdc-button:hover {
+  background-color: #1f2937 !important;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.25) !important;
+  color: #ffffff !important;
+}
+
+.mdc-button__ripple {
+  display: none !important;
 }
 
 .mdc-floating-label {
@@ -320,27 +1337,33 @@ select {
 
 /* Enter Button Global CSS Here */
 .mwb-btn {
-  border-radius: 30px;
-  border: 1px solid #2196f3;
+  background-color: #111827;
+  border: none;
+  border-radius: 999px;
   color: #ffffff;
   cursor: pointer;
   display: inline-block;
-  font-family: "NunitoSans-Regular";
+  font-family: "NunitoSans-Bold", sans-serif;
   font-size: 14px;
-  font-weight: 400;
+  font-weight: 700;
   min-width: 140px;
   outline: 0;
-  padding: 16px 32px;
+  padding: 12px 28px;
   text-align: center;
-  text-transform: capitalize;
+  text-transform: none;
+  letter-spacing: 0.3px;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18);
+  transition: background-color 0.2s, box-shadow 0.2s;
 }
 
 .mwb-btn:hover, .mwb-btn:active, .mwb-btn:focus {
+  background-color: #1f2937;
   color: #ffffff;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.25);
 }
 
 .mwb-btn__filled {
-  background-color: #2196f3;
+  background-color: #111827;
 }
 
 /* Header CSS */
@@ -350,157 +1373,511 @@ select {
 /* About page css */
 /* Home Page CSS */
 /* Overview page css */
-.mwb-overview__wrapper {
-  width: calc(100% - 20px);
+/* =============================================
+   Overview Page — New Design
+   ============================================= */
+.wps-overview-wrap {
+  padding: 24px 0 40px;
 }
 
-.mwb-overview__wrapper .mwb-overview__banner {
-  background-color: #ffffff;
-  margin: 10px 0 25px;
-  overflow: hidden;
-  padding: 10px;
+/* Hero */
+.wps-overview-hero {
+  text-align: center;
+  padding: 32px 20px 28px;
+  background: #ffffff;
+  border-radius: 12px;
+  margin-bottom: 24px;
 }
 
-.mwb-overview__wrapper .mwb-overview__banner img {
-  width: 100%;
+.wps-overview-hero__icon {
+  width: 72px;
+  height: 72px;
+  border-radius: 50%;
+  background-color: #ede9fe;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 16px;
 }
 
-.mwb-overview__wrapper .mwb-overview__content .mwb-overview__content-description {
-  background-color: #ffffff;
-  margin-bottom: 30px;
-  padding: 25px 0;
-  text-align: left;
+.wps-overview-hero__icon .material-icons {
+  font-size: 36px;
+  color: #6d28d9;
 }
 
-.mwb-overview__wrapper .mwb-overview__content .mwb-overview__content-description h2 {
-  color: #163062;
+.wps-overview-hero__label {
+  font-size: 12px;
+  font-family: "NunitoSans-Bold", sans-serif;
+  font-weight: 700;
+  color: #f5a623;
+  letter-spacing: 1.5px;
+  text-transform: uppercase;
+  margin: 0 0 10px;
+}
+
+.wps-overview-hero__title {
   font-size: 30px;
-  font-weight: 600;
-  letter-spacing: 0.5px;
-  line-height: 150%;
-  margin: 10px 0px;
-  text-align: left;
+  font-family: "NunitoSans-Bold", sans-serif;
+  font-weight: 700;
+  color: #1a0f40;
+  margin: 0 0 12px;
+  line-height: 1.3;
 }
 
-.mwb-overview__wrapper .mwb-overview__content .mwb-overview__content-description p {
-  color: #565857;
+.wps-overview-hero__desc {
+  font-size: 14px;
+  color: #6b7280;
+  max-width: 560px;
+  margin: 0 auto;
+  line-height: 1.6;
+}
+
+/* Features Section */
+.wps-overview-features {
+  background: #ffffff;
+  border-radius: 12px;
+  padding: 28px 28px 8px;
+  margin-bottom: 24px;
+}
+
+.wps-overview-features__title {
   font-size: 16px;
-  letter-spacing: 0.5px;
-}
-
-.mwb-overview__wrapper .mwb-overview__content .mwb-overview__content-description h3 {
-  color: #163062;
-  font-size: 18px;
+  font-family: "NunitoSans-SemiBold", sans-serif;
   font-weight: 600;
-  letter-spacing: 0.3px;
-  margin-bottom: 15px;
-  margin-top: 25px;
+  color: #374151;
+  text-align: center;
+  margin: 0 0 24px;
 }
 
-.mwb-overview__wrapper .mwb-overview__content .mwb-overview__content-description .mwb-overview__features {
-  list-style: none;
-}
-
-.mwb-overview__wrapper .mwb-overview__content .mwb-overview__content-description .mwb-overview__features li {
-  color: #565857;
-  font-size: 16px;
-  letter-spacing: 0.5px;
-  line-height: 24px;
-}
-
-.mwb-overview__wrapper .mwb-overview__content .mwb-overview__content-description .mwb-overview__features li:before {
-  color: #1a3365;
-  content: "⚬";
-  font-size: 20px;
-  font-weight: 400;
-  margin-right: 10px;
-  vertical-align: middle;
-}
-
-.mwb-overview__wrapper .mwb-overview__content h2 {
-  color: #163062;
-  font-size: 30px;
-  font-weight: 600;
-  font-weight: 600;
-  letter-spacing: 0.5px;
-  line-height: 150%;
-  margin: 10px 0px;
-  text-align: left;
-}
-
-.mwb-overview__wrapper .mwb-overview__content .mwb-overview__keywords {
-  display: flex;
-  flex-wrap: wrap;
-  margin: 0 -15px;
-}
-
-.mwb-overview__wrapper .mwb-overview__content .mwb-overview__keywords .mwb-overview__keywords-item {
-  display: flex;
-  flex-wrap: wrap;
-  flex: 0 0 33.33%;
+.wps-overview-features__grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 20px;
   margin-bottom: 20px;
-  max-width: 33.33%;
-  padding: 0 15px;
 }
 
-.mwb-overview__wrapper .mwb-overview__content .mwb-overview__keywords .mwb-overview__keywords-item .mwb-overview__keywords-card {
-  background-color: #ffffff;
+.wps-overview-feature-card {
+  background: #ffffff;
+  border: 1px solid #e8e8f0;
   border-radius: 10px;
-  border: 1px solid #dddddd;
-  box-shadow: 0px 4px 10px #efefef;
-  color: #ffffff;
-  flex-grow: 1;
-  padding: 30px;
+  padding: 20px;
 }
 
-.mwb-overview__wrapper .mwb-overview__content .mwb-overview__keywords .mwb-overview__keywords-item .mwb-overview__keywords-card .mwb-overview__keywords-image {
-  overflow: hidden;
+.wps-overview-feature-card__icon {
+  width: 36px;
+  height: 36px;
+  border-radius: 8px;
+  background-color: #eff6ff;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 12px;
 }
 
-.mwb-overview__wrapper .mwb-overview__content .mwb-overview__keywords .mwb-overview__keywords-item .mwb-overview__keywords-card .mwb-overview__keywords-image img {
-  max-width: 80px;
-  -o-object-fit: cover;
-     object-fit: cover;
-  width: auto;
+.wps-overview-feature-card__icon .material-icons {
+  font-size: 20px;
+  color: #3b82f6;
 }
 
-.mwb-overview__wrapper .mwb-overview__content .mwb-overview__keywords .mwb-overview__keywords-item .mwb-overview__keywords-card .mwb-overview__keywords-text .mwb-overview__keywords-heading {
-  color: #163062;
-  font-size: 28px;
-  font-weight: 600;
-  letter-spacing: 0.3px;
-  line-height: 38px;
-  margin: 15px 0;
+.wps-overview-feature-card__title {
+  font-size: 14px;
+  font-family: "NunitoSans-Bold", sans-serif;
+  font-weight: 700;
+  color: #1a0f40;
+  margin: 0 0 8px;
+  line-height: 1.4;
 }
 
-.mwb-overview__wrapper .mwb-overview__content .mwb-overview__keywords .mwb-overview__keywords-item .mwb-overview__keywords-card .mwb-overview__keywords-text .mwb-overview__keywords-description {
-  color: #565857;
-  font-size: 16px;
-  letter-spacing: 0.5px;
+.wps-overview-feature-card__desc {
+  font-size: 13px;
+  color: #6b7280;
+  line-height: 1.6;
+  margin: 0;
+}
+
+/* Footer CTA */
+.wps-overview-cta {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 32px;
+  padding: 20px 28px;
+  flex-wrap: wrap;
+}
+
+.wps-overview-cta__text {
+  text-align: center;
+}
+
+.wps-overview-cta__heading {
+  font-size: 15px;
+  font-family: "NunitoSans-Bold", sans-serif;
+  font-weight: 700;
+  color: #1a0f40;
+  margin: 0 0 4px;
+}
+
+.wps-overview-cta__sub {
+  font-size: 13px;
+  color: #6b7280;
+  margin: 0;
+}
+
+.wps-overview-cta__actions {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.wps-overview-cta__btn {
+  display: inline-block;
+  background-color: #111827;
+  color: #ffffff !important;
+  border: none;
+  border-radius: 999px;
+  padding: 10px 22px;
+  font-size: 13px;
+  font-family: "NunitoSans-Bold", sans-serif;
+  font-weight: 700;
+  text-decoration: none;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18);
+  transition: background-color 0.2s, box-shadow 0.2s;
+  letter-spacing: 0.2px;
+  cursor: pointer;
+}
+
+.wps-overview-cta__btn:hover {
+  background-color: #1f2937;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.25);
+  color: #ffffff !important;
 }
 
 /* overview page css ends */
+
+/* =============================================
+   Dashboard Two-Column Layout
+   ============================================= */
+.mwb-dashboard-body {
+  display: flex;
+  align-items: flex-start;
+  gap: 0;
+}
+
+.mwb-dashboard-body .mwb-section {
+  flex: 1;
+  min-width: 0;
+}
+
+/* =============================================
+   Right Sidebar
+   ============================================= */
+.wps-dashboard-sidebar {
+  width: 260px;
+  flex-shrink: 0;
+  padding: 20px 16px 20px 0;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.wps-sidebar-card {
+  background: #ffffff;
+  border: 1px solid #e8e8f0;
+  border-radius: 10px;
+  padding: 16px;
+}
+
+.wps-sidebar-card__title {
+  font-size: 14px;
+  font-family: "NunitoSans-Bold", sans-serif;
+  font-weight: 700;
+  color: #1a0f40;
+  margin: 0 0 12px;
+  line-height: 1.3;
+}
+
+.wps-sidebar-card__subtitle {
+  font-size: 12px;
+  color: #6b7280;
+  margin: 0 0 12px;
+  line-height: 1.5;
+}
+
+/* Help links */
+.wps-sidebar-card__link {
+  display: block;
+  background: #f9fafb;
+  border: 1px solid #e8e8f0;
+  border-radius: 8px;
+  padding: 10px 14px;
+  font-size: 13px;
+  font-family: "NunitoSans-SemiBold", sans-serif;
+  font-weight: 600;
+  color: #374151 !important;
+  text-decoration: none !important;
+  margin-bottom: 8px;
+  transition: background-color 0.2s, border-color 0.2s;
+}
+
+.wps-sidebar-card__link:last-of-type {
+  margin-bottom: 0;
+}
+
+.wps-sidebar-card__link:hover {
+  background: #f0f0f8;
+  border-color: #c4b5fd;
+  color: #1a0f40 !important;
+}
+
+/* Grow header */
+.wps-sidebar-card__grow-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+
+.wps-sidebar-card__star {
+  color: #f5a623;
+  font-size: 18px;
+  line-height: 1;
+  flex-shrink: 0;
+  margin-left: 8px;
+}
+
+/* Service links — card style */
+.wps-sidebar-card__service-link {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  background: #ffffff;
+  border: 1px solid #e8e8f0;
+  border-radius: 10px;
+  padding: 12px;
+  margin-bottom: 8px;
+  text-decoration: none !important;
+  transition: border-color 0.2s, background-color 0.2s;
+}
+
+.wps-sidebar-card__service-link:last-of-type {
+  margin-bottom: 0;
+}
+
+.wps-sidebar-card__service-link:hover {
+  border-color: #c4b5fd;
+  background: #faf5ff;
+}
+
+.wps-sidebar-card__service-link:hover .wps-sidebar-card__service-name {
+  color: #2d1b5e;
+}
+
+.wps-sidebar-card__service-icon {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.wps-sidebar-card__service-icon .material-icons {
+  font-size: 16px;
+}
+
+.wps-sidebar-card__service-icon--search {
+  background-color: #fef9c3;
+}
+.wps-sidebar-card__service-icon--search .material-icons { color: #ca8a04; }
+
+.wps-sidebar-card__service-icon--ads {
+  background-color: #ede9fe;
+}
+.wps-sidebar-card__service-icon--ads .material-icons { color: #7c3aed; }
+
+.wps-sidebar-card__service-icon--speed {
+  background-color: #ede9fe;
+}
+.wps-sidebar-card__service-icon--speed .material-icons { color: #7c3aed; }
+
+.wps-sidebar-card__service-icon--dev {
+  background-color: #ede9fe;
+}
+
+/* WooCommerce "woo" badge icon */
+.wps-woo-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: #7c3aed;
+  color: #ffffff;
+  font-size: 9px;
+  font-weight: 800;
+  font-family: "NunitoSans-ExtraBold", sans-serif;
+  border-radius: 5px;
+  padding: 3px 6px;
+  letter-spacing: 0.5px;
+  line-height: 1.2;
+}
+.wps-woo-icon::after {
+  content: "woo";
+}
+
+.wps-sidebar-card__service-name {
+  font-size: 12px;
+  font-family: "NunitoSans-SemiBold", sans-serif;
+  font-weight: 600;
+  color: #374151;
+  margin: 0 0 2px;
+  line-height: 1.3;
+}
+
+.wps-sidebar-card__service-desc {
+  font-size: 11px;
+  color: #9ca3af;
+  margin: 0;
+  line-height: 1.3;
+}
+
+.wps-sidebar-card__chevron {
+  font-size: 16px !important;
+  color: #9ca3af;
+  margin-left: auto;
+  flex-shrink: 0;
+}
+
+.wps-sidebar-card__expert-btn {
+  display: block;
+  text-align: center;
+  background-color: #111827;
+  color: #ffffff !important;
+  border-radius: 999px;
+  padding: 10px 16px;
+  font-size: 13px;
+  font-family: "NunitoSans-Bold", sans-serif;
+  font-weight: 700;
+  text-decoration: none !important;
+  margin-top: 14px;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18);
+  transition: background-color 0.2s;
+}
+
+.wps-sidebar-card__expert-btn:hover {
+  background-color: #1f2937;
+  color: #ffffff !important;
+}
+
+.wps-sidebar-card__services-by {
+  font-size: 11px;
+  color: #9ca3af;
+  text-align: center;
+  margin: 8px 0 0;
+}
+
+/* Dark button (Contact Us) */
+.wps-sidebar-card__dark-btn {
+  display: block;
+  text-align: center;
+  background-color: #111827;
+  color: #ffffff !important;
+  border-radius: 999px;
+  padding: 10px 16px;
+  font-size: 13px;
+  font-family: "NunitoSans-Bold", sans-serif;
+  font-weight: 700;
+  text-decoration: none !important;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18);
+  transition: background-color 0.2s;
+}
+
+.wps-sidebar-card__dark-btn:hover {
+  background-color: #1f2937;
+  color: #ffffff !important;
+}
+
+/* Outline button (View More Plugins) */
+.wps-sidebar-card__outline-btn {
+  display: block;
+  text-align: center;
+  background-color: #ffffff;
+  color: #1a0f40 !important;
+  border: 1.5px solid #c4b5fd;
+  border-radius: 999px;
+  padding: 9px 16px;
+  font-size: 13px;
+  font-family: "NunitoSans-Bold", sans-serif;
+  font-weight: 700;
+  text-decoration: none !important;
+  transition: background-color 0.2s, border-color 0.2s;
+}
+
+.wps-sidebar-card__outline-btn:hover {
+  background-color: #f5f3ff;
+  border-color: #7c3aed;
+  color: #1a0f40 !important;
+}
 /*====================================
 =            Tabs Section            =
 ====================================*/
 .mwb-navbar {
   padding: 0 32px;
-  border-bottom: 1px solid rgba(63, 71, 86, 0.25);
+  background-color: #ffffff;
+  border-bottom: 1px solid #e0e0e8;
+  margin-right: 15px;
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.mwb-navbar__version {
+  font-size: 13px;
+  font-family: "NunitoSans-SemiBold", sans-serif;
+  color: #9ca3af;
+  white-space: nowrap;
+  flex-shrink: 0;
+  padding: 16px 0;
 }
 
 .mwb-navbar .mwb-navbar__items {
   display: flex;
   flex-wrap: wrap;
+  gap: 0;
+  flex: 1;
 }
 
 .mwb-navbar .mwb-navbar__items li {
-  margin-right: 32px;
+  margin-right: 0;
   margin-bottom: 0;
 }
 
 .mwb-navbar .mwb-navbar__items li a {
-  padding: 18px 0;
-  color: #000000;
+  display: inline-block;
+  padding: 16px 20px;
+  color: #2d1b5e;
+  font-size: 13px;
+  font-family: "NunitoSans-SemiBold", sans-serif;
+  font-weight: 600;
+  letter-spacing: 0.2px;
+  border-bottom: 3px solid transparent;
+  transition: color 0.2s, border-color 0.2s;
+}
+
+.mwb-navbar .mwb-navbar__items li a:hover {
+  color: #1a0f40 !important;
+  border-bottom-color: rgba(245, 166, 35, 0.4);
+}
+
+.mwb-navbar .mwb-navbar__items li a.active {
+  color: #1a0f40 !important;
+  font-family: "NunitoSans-Bold", sans-serif;
+  font-weight: 700;
+  border-bottom-color: #f5a623;
+  position: static;
+}
+
+.mwb-navbar .mwb-navbar__items li a.active:after {
+  display: none;
 }
 
 /*=====   Tabs Section CSS Ends  ======*/
@@ -553,24 +1930,31 @@ select {
 }
 
 .mwb-mbfw-wrap .mwb_mbfw_license_text #mwb_mbfw_license_form button {
-  background-color: #163062;
-  text-transform: uppercase;
+  background-color: #111827;
+  color: #ffffff;
+  text-transform: none;
   width: 100%;
-  height: 40px;
-  letter-spacing: 1.5px;
-  border: 1px solid #163062;
-  transition: 0.5s ease;
-  font-weight: 600;
+  height: auto;
+  padding: 11px 28px;
+  letter-spacing: 0.3px;
+  border: none;
+  border-radius: 999px;
+  font-weight: 700;
+  font-size: 14px;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18);
+  transition: background-color 0.2s, box-shadow 0.2s;
+  cursor: pointer;
 }
 
 .mwb-mbfw-wrap .mwb_mbfw_license_text #mwb_mbfw_license_form button:hover {
-  color: #163062;
-  background-color: #ffffff;
+  background-color: #1f2937;
+  color: #ffffff;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.25);
 }
 
 .mwb-mbfw-wrap .mwb_mbfw_license_text #mwb_mbfw_license_form button:focus {
   outline: none;
-  box-shadow: none;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18);
 }
 
 /*=====  License Section CSS ends  ======*/
@@ -718,9 +2102,26 @@ select {
 }
 
 .mwb_bfw_config_tab .mwb-form-group .mwb-form-group__control input.bfwp_availability_page_calendar {
-  border-radius: 5px;
-  min-height: 32px;
-  padding: 8px 16px;
+  border-radius: 10px !important;
+  min-height: 48px !important;
+  padding: 10px 18px !important;
+  border: 2px solid #e8cdfd !important;
+  color: #32126d !important;
+  font-size: 16px !important;
+  font-family: "NunitoSans-Regular", sans-serif !important;
+  box-shadow: 0 0 0 4px rgba(232, 205, 253, 0.28) !important;
+  width: min(100%, 480px) !important;
+  flex: 0 1 480px !important;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease !important;
+  outline: none !important;
+  background: #ffffff !important;
+  display: block !important;
+  box-sizing: border-box !important;
+}
+
+.mwb_bfw_config_tab .mwb-form-group .mwb-form-group__control input.bfwp_availability_page_calendar:focus {
+  border-color: #d7b5fb !important;
+  box-shadow: 0 0 0 6px rgba(215, 181, 251, 0.24) !important;
 }
 
 .mwb_bfw_config_tab .mwb-form-group .mwb-form-group__control label.mdl-textfield__label {
@@ -784,22 +2185,36 @@ select {
   padding: 15px;
 }
 
-.mwb-section #submit, .mwb-section .edit-tag-actions .button {
-  background-color: #2196f3;
-  border: none;
-  border-radius: 50px;
-  padding: 8px 16px;
-  font-size: 14px;
-  font-family: "NunitoSans-Regular";
-  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
+.mwb-section #submit, .mwb-section .edit-tag-actions .button,
+.mwb-mbfw-wrap input[type="submit"],
+.mwb-mbfw-wrap button[type="submit"],
+.mwb-mbfw-wrap .button-primary {
+  background-color: #111827 !important;
+  border: none !important;
+  border-radius: 999px !important;
+  padding: 11px 28px !important;
+  font-size: 14px !important;
+  font-family: "NunitoSans-Bold", sans-serif !important;
+  font-weight: 700 !important;
+  color: #ffffff !important;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18) !important;
   margin-top: 15px;
-  opacity: 0.9;
-  text-transform: uppercase;
-  transition: opacity 0.3s ease;
+  text-transform: none !important;
+  letter-spacing: 0.3px !important;
+  cursor: pointer !important;
+  transition: background-color 0.2s, box-shadow 0.2s !important;
+  opacity: 1 !important;
+  line-height: 1.4 !important;
+  height: auto !important;
 }
 
-.mwb-section #submit:hover, .mwb-section .edit-tag-actions .button:hover {
-  opacity: 1;
+.mwb-section #submit:hover, .mwb-section .edit-tag-actions .button:hover,
+.mwb-mbfw-wrap input[type="submit"]:hover,
+.mwb-mbfw-wrap button[type="submit"]:hover,
+.mwb-mbfw-wrap .button-primary:hover {
+  background-color: #1f2937 !important;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.25) !important;
+  color: #ffffff !important;
 }
 
 .mwb-section h1,
@@ -892,6 +2307,545 @@ select {
 .mwb-section .wps-bfw-form-field .wps-form-field-wrap span {
   padding-top: 5px;
   display: block;
+}
+
+/* =============================================
+   Inline Taxonomy UI (Additional Costs / Services)
+   ============================================= */
+
+.mwb-inline-taxonomy {
+  font-family: "NunitoSans-Regular", sans-serif;
+}
+
+.mwb-inline-tax-notice {
+  margin-bottom: 16px;
+}
+
+.mwb-inline-taxonomy__layout {
+  display: flex;
+  gap: 32px;
+  align-items: flex-start;
+}
+
+/* Left: Add New Form */
+.mwb-inline-taxonomy__add-col {
+  flex: 0 0 320px;
+  background: #ffffff;
+  border-radius: 8px;
+  padding: 20px;
+}
+
+.mwb-inline-taxonomy__desc {
+  font-size: 13px;
+  color: #50575e;
+  margin-bottom: 16px;
+  line-height: 1.5;
+}
+
+.mwb-inline-taxonomy__form-title {
+  font-size: 16px;
+  font-weight: 700;
+  color: #1d2327;
+  margin-bottom: 16px;
+}
+
+.mwb-tax-field {
+  margin-bottom: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.mwb-tax-field label {
+  font-size: 13px;
+  font-weight: 600;
+  color: #1d2327;
+}
+
+.mwb-tax-field__input input[type="text"],
+.mwb-tax-field__input input[type="number"],
+.mwb-tax-field__input textarea {
+  width: 100%;
+  border: 2px solid #bab7c1;
+  border-radius: 12px;
+  padding: 10px 16px;
+  font-size: 13px;
+  color: #6d28d9;
+  background: #fff;
+  outline: none;
+  transition: border-color 0.2s, box-shadow 0.2s;
+  box-sizing: border-box;
+}
+
+.mwb-tax-field__input input[type="text"]:focus,
+.mwb-tax-field__input input[type="number"]:focus,
+.mwb-tax-field__input textarea:focus {
+  border-color: #7c3aed;
+  box-shadow: 0 0 0 3px rgba(167, 139, 250, 0.25);
+}
+
+.mwb-tax-field__input textarea {
+  resize: vertical;
+  min-height: 80px;
+}
+
+.mwb-tax-field__input .description {
+  font-size: 11px;
+  color: #646970;
+  margin-top: 4px;
+}
+
+/* Toggle (checkbox) fields */
+.mwb-tax-field--toggle .mwb-tax-field__input {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.mwb-tax-field--toggle .description {
+  margin-top: 0;
+}
+
+/* Visually hide the real checkbox — JS wraps it in .mwb-tax-switch label */
+.mwb-tax-toggle {
+  position: absolute !important;
+  opacity: 0 !important;
+  width: 0 !important;
+  height: 0 !important;
+  margin: 0 !important;
+  pointer-events: none;
+}
+
+/* Switch wrapper label */
+.mwb-tax-switch {
+  display: inline-flex;
+  align-items: center;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+/* Visual track */
+.mwb-tax-switch__track {
+  display: block;
+  width: 52px;
+  height: 28px;
+  border-radius: 999px;
+  background: #e5e7eb;
+  border: 2px solid #d1d5db;
+  position: relative;
+  transition: background 0.2s, border-color 0.2s;
+  flex-shrink: 0;
+}
+
+/* Knob */
+.mwb-tax-switch__track::before {
+  content: "";
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: #fff;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  transition: left 0.2s ease, background 0.2s;
+}
+
+/* Checked state — hidden input sibling targets the track span */
+.mwb-tax-toggle:checked + .mwb-tax-switch__track {
+  background: #fef3c7;
+  border-color: #f59e0b;
+}
+
+.mwb-tax-toggle:checked + .mwb-tax-switch__track::before {
+  left: 24px;
+  background: #f59e0b;
+}
+
+.mwb-tax-field--submit {
+  margin-top: 20px;
+}
+
+.mwb-btn--primary {
+  display: inline-block;
+  background-color: #111827;
+  color: #ffffff !important;
+  border: none;
+  border-radius: 999px;
+  padding: 10px 28px;
+  font-size: 13px;
+  font-family: "NunitoSans-Bold", sans-serif;
+  font-weight: 700;
+  text-decoration: none !important;
+  cursor: pointer;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18);
+  transition: background-color 0.2s;
+}
+
+.mwb-btn--primary:hover {
+  background-color: #1f2937;
+  color: #ffffff !important;
+}
+
+/* Edit form (full-width, matching term.php layout) */
+.mwb-inline-taxonomy__edit-wrap {
+  max-width: 700px;
+}
+
+.mwb-inline-taxonomy__edit-title-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 20px;
+}
+
+.mwb-inline-taxonomy__edit-title {
+  font-size: 18px;
+  font-weight: 700;
+  color: #1d2327;
+  margin: 0;
+}
+
+.mwb-tax-back-link {
+  font-size: 13px;
+  color: #646970;
+  text-decoration: none;
+}
+
+.mwb-tax-back-link:hover {
+  color: #2196f3;
+}
+
+.mwb-inline-taxonomy__edit-form {
+  background: #fff;
+  border: 1px solid #c3c4c7;
+  border-radius: 6px;
+  padding: 24px;
+}
+
+.mwb-edit-field {
+  display: flex;
+  align-items: flex-start;
+  gap: 20px;
+  padding: 12px 0;
+  border-bottom: 1px solid #f0f0f0;
+}
+
+.mwb-edit-field:last-child {
+  border-bottom: none;
+}
+
+.mwb-edit-field > label {
+  flex: 0 0 160px;
+  font-size: 13px;
+  font-weight: 600;
+  color: #1d2327;
+  padding-top: 6px;
+}
+
+.mwb-edit-field__control {
+  flex: 1;
+}
+.mwb-form-group__control textarea,
+.wps-field-inline input,
+.mwb-edit-field__control input{
+border: 2px solid #cbcacd;
+width: 100%;
+font-size: 13px;
+  border-radius: 12px;
+  padding: 10px 16px;
+  font-size: 13px;
+
+}
+.mwb-edit-field__text {
+  width: 100%;
+  border: 2px solid #cbcacd;
+  border-radius: 12px;
+  padding: 10px 16px;
+  font-size: 13px;
+  color: #6d28d9;
+  background: #fff;
+  outline: none;
+  transition: border-color 0.2s, box-shadow 0.2s;
+  box-sizing: border-box;
+}
+
+.mwb-edit-field__text:focus {
+  border-color: #7c3aed;
+  box-shadow: 0 0 0 3px rgba(167, 139, 250, 0.25);
+}
+
+.mwb-edit-field__textarea {
+  width: 100%;
+  border: 2px solid #cbcacd;
+  border-radius: 12px;
+  padding: 10px 16px;
+  font-size: 13px;
+  color: #6d28d9;
+  background: #fff;
+  outline: none;
+  transition: border-color 0.2s, box-shadow 0.2s;
+  box-sizing: border-box;
+  resize: vertical;
+  min-height: 100px;
+}
+
+.mwb-edit-field__textarea:focus {
+  border-color: #cbcacd;
+  box-shadow: 0 0 0 3px rgba(167, 139, 250, 0.25);
+}
+
+.mwb-edit-field__control .description {
+  font-size: 11px;
+  color: #646970;
+  margin-top: 4px;
+}
+
+.mwb-edit-field--toggle .mwb-edit-field__control {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding-top: 4px;
+}
+
+.mwb-edit-field--toggle .description {
+  margin-top: 0;
+}
+
+.mwb-edit-field--actions {
+  padding-top: 20px;
+  border-top: 1px solid #e0e0e0;
+  border-bottom: none;
+}
+
+.mwb-edit-actions {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.mwb-edit-delete-link {
+  font-size: 13px;
+  color: #d63638;
+  text-decoration: none;
+}
+
+.mwb-edit-delete-link:hover {
+  color: #a00;
+  text-decoration: underline;
+}
+
+/* Right: Terms Listing Table */
+.mwb-inline-taxonomy__table-col {
+  flex: 1;
+  min-width: 0;
+}
+
+.mwb-inline-taxonomy__search-form {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 12px;
+}
+
+.mwb-inline-taxonomy__search-input {
+  border: 2px solid #cbcacd !important;
+  border-radius: 999px !important;
+  padding: 9px 20px !important;
+  font-size: 13px !important;
+  color: #6d28d9 !important;
+  background: #fff !important;
+  outline: none !important;
+  width: 220px !important;
+  box-shadow: none !important;
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.mwb-inline-taxonomy__search-input:focus {
+  border-color: #cbcacd !important;
+  box-shadow: 0 0 0 3px rgba(167, 139, 250, 0.25) !important;
+}
+
+/* Search submit button — navy pill */
+.mwb-inline-taxonomy__search-form button,
+.mwb-inline-taxonomy__search-form button.button {
+  display: inline-block !important;
+  background-color: #111827 !important;
+  color: #ffffff !important;
+  border: none !important;
+  border-radius: 999px !important;
+  padding: 9px 22px !important;
+  font-size: 13px !important;
+  font-weight: 700 !important;
+  line-height: 1.4 !important;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18) !important;
+  cursor: pointer !important;
+  transition: background-color 0.2s !important;
+}
+
+.mwb-inline-taxonomy__search-form button:hover {
+  background-color: #1f2937 !important;
+  color: #fff !important;
+}
+
+.mwb-inline-taxonomy__bulk-bar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+
+.mwb-inline-taxonomy__bulk-bar--bottom {
+  margin-top: 10px;
+  margin-bottom: 0;
+}
+
+/* Bulk actions select — purple pill (override global select rules) */
+.mwb-inline-taxonomy__bulk-bar select {
+  border: 2px solid #cbcacd !important;
+  border-radius: 999px !important;
+  padding: 9px 40px 9px 20px !important;
+  font-size: 13px !important;
+  color: #6d28d9 !important;
+  background-color: #fff !important;
+  -webkit-appearance: none !important;
+  -moz-appearance: none !important;
+  appearance: none !important;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8'%3E%3Cpath d='M1 1l5 5 5-5' stroke='%236d28d9' stroke-width='2' fill='none' stroke-linecap='round'/%3E%3C/svg%3E") !important;
+  background-repeat: no-repeat !important;
+  background-position: right 14px center !important;
+  cursor: pointer;
+  outline: none;
+  min-width: 160px;
+  box-shadow: none !important;
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.mwb-inline-taxonomy__bulk-bar select:focus {
+  border-color: #7c3aed !important;
+  box-shadow: 0 0 0 3px rgba(167, 139, 250, 0.25) !important;
+}
+
+/* Apply button — dark navy pill */
+.mwb-inline-taxonomy__apply-btn,
+.mwb-inline-taxonomy__apply-btn.button {
+  display: inline-block !important;
+  background-color: #111827 !important;
+  color: #ffffff !important;
+  border: none !important;
+  border-radius: 999px !important;
+  padding: 9px 24px !important;
+  font-size: 13px !important;
+  font-weight: 700 !important;
+  line-height: 1.4 !important;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18) !important;
+  cursor: pointer !important;
+  transition: background-color 0.2s !important;
+}
+
+.mwb-inline-taxonomy__apply-btn:hover,
+.mwb-inline-taxonomy__apply-btn.button:hover {
+  background-color: #1f2937 !important;
+  color: #ffffff !important;
+}
+
+.mwb-inline-taxonomy__count {
+  margin-left: auto;
+  font-size: 13px;
+  color: #646970;
+}
+
+.mwb-inline-taxonomy__table {
+  border-collapse: collapse;
+  width: 100%;
+  background: #fff;
+  border: 1px solid #c3c4c7;
+  border-radius: 4px;
+}
+
+.mwb-inline-taxonomy__table th,
+.mwb-inline-taxonomy__table td {
+  padding: 8px 12px;
+  font-size: 13px;
+  text-align: left;
+  border-bottom: 1px solid #f0f0f0;
+}
+
+.mwb-inline-taxonomy__table thead th,
+.mwb-inline-taxonomy__table tfoot th {
+  background: #f6f7f7;
+  font-weight: 600;
+  color: #1d2327;
+}
+
+.mwb-inline-taxonomy__table .check-column {
+  width: 56px !important;
+  padding: 4px 10px !important;
+  vertical-align: middle !important;
+  text-align: center !important;
+}
+
+/* Compact .wps-checkbox halo for table cells — keep inline-flex so text-align:center works */
+.mwb-tax-table-cb.wps-checkbox {
+  display: inline-flex !important;
+  width: 34px;
+  height: 34px;
+  vertical-align: middle;
+  justify-content: flex-start;
+}
+
+.mwb-tax-table-cb .wps-checkbox__box {
+  width: 18px;
+  height: 18px;
+  border-radius: 5px;
+}
+
+.mwb-tax-table-cb .wps-checkbox__input:checked + .wps-checkbox__box::after {
+  width: 4px;
+  height: 8px;
+}
+
+.mwb-inline-taxonomy__row:hover td {
+  background: #f6f7f7;
+}
+
+.mwb-inline-taxonomy__row .row-actions {
+  visibility: hidden;
+  font-size: 11px;
+  color: #646970;
+  margin-top: 2px;
+}
+
+.mwb-inline-taxonomy__row:hover .row-actions {
+  visibility: visible;
+}
+
+.mwb-inline-taxonomy__no-items {
+  text-align: center;
+  color: #646970;
+  padding: 20px !important;
+}
+
+.mwb-tax-icon--yes {
+  color: #008a20;
+  font-weight: 700;
+}
+
+.mwb-tax-icon--no {
+  color: #d63638;
+  font-weight: 700;
+}
+
+/* Responsive */
+@media (max-width: 1200px) {
+  .mwb-inline-taxonomy__layout {
+    flex-direction: column;
+  }
+  .mwb-inline-taxonomy__add-col {
+    flex: 1 1 auto;
+    width: 100%;
+  }
 }
 
 .mwb-taxonomy-section_wrap {
@@ -998,11 +2952,22 @@ select {
 }
 
 @media (max-width: 768px){
+  .mwb-dashboard-body{
+    flex-direction: column;
+    gap: 25px;
+  }
+  .wps-tab-highlight-block {
+   
+    flex-direction: column;
+}
   .mwb-header-container {
     justify-content: flex-start;
+    padding: 8px 16px;
   }
+
   .mwb-header-container .mwb-header-title {
     max-width: 100%;
+    font-size: 13px;
   }
   .mwb-header-container .mwb-link {
     margin-top: 15px;
@@ -1010,9 +2975,8 @@ select {
   .mwb-header-container span {
     margin: 15px 5px 0;
   }
-  .mwb-overview__wrapper .mwb-overview__content .mwb-overview__keywords .mwb-overview__keywords-item {
-    flex: 0 0 100%;
-    max-width: 100%;
+  .wps-overview-features__grid {
+    grid-template-columns: 1fr;
   }
   .mwb_bfw_config_tab h3.nav-tab-wrapper {
     border-bottom: 2px solid #c3c4c7;
@@ -1049,9 +3013,8 @@ select {
 }
 
 @media (max-width: 992px){
-  .mwb-overview__wrapper .mwb-overview__content .mwb-overview__keywords .mwb-overview__keywords-item {
-    flex: 0 0 50%;
-    max-width: 50%;
+  .wps-overview-features__grid {
+    grid-template-columns: repeat(2, 1fr);
   }
   .mwb_bfw_config_tab .wps-bfwp__integration-wrap {
     display: block;
@@ -1072,11 +3035,347 @@ select {
   .mwb-section .wps-bfw-form-field .wps-form-field-wrap {
     padding-top: 10px;
   }
+  .mwb-form-group {
+    flex-direction: column;
+    align-items: flex-start;
+  }
   .mwb-form-group .mwb-form-group__label {
+    max-width: 100%;
     margin-bottom: 12px;
   }
   .mwb-form-group .mwb-form-group__control {
     max-width: 100%;
+    padding: 0;
   }
 }
+.check-column label.wps-checkbox:hover {
+    background: none;
+}
 
+.mbfw-expert-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 100000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 32px 20px;
+}
+
+.mbfw-expert-modal[hidden] {
+  display: none !important;
+}
+
+.mbfw-expert-modal__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.52);
+  backdrop-filter: blur(4px);
+}
+
+.mbfw-expert-modal__dialog {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  width: min(980px, 100%);
+  max-height: calc(100vh - 64px);
+  border: 1px solid #e5e7eb;
+  border-radius: 28px;
+  background: linear-gradient(180deg, #ffffff 0%, #f8fafc 100%);
+  box-shadow: 0 28px 64px rgba(15, 23, 42, 0.24);
+  overflow: hidden;
+}
+
+.mbfw-expert-modal__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 22px 22px 18px;
+  border-bottom: 1px solid #e5e7eb;
+  background: linear-gradient(180deg, #ffffff 0%, #f8fafc 100%);
+}
+
+.mbfw-expert-modal__copy {
+  min-width: 0;
+}
+
+.mbfw-expert-modal__copy h2 {
+  margin: 0 0 6px;
+  color: #111827;
+  font-size: 24px;
+  line-height: 1.15;
+  font-weight: 800;
+  letter-spacing: -0.03em;
+}
+
+.mbfw-expert-modal__copy p {
+  margin: 0;
+  color: #6b7280;
+  font-size: 14px;
+  line-height: 1.6;
+}
+
+.mbfw-expert-modal__close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 42px;
+  height: 42px;
+  flex: 0 0 42px;
+  border: 1px solid #e5e7eb;
+  border-radius: 14px;
+  background: #fff;
+  color: #111827;
+  cursor: pointer;
+  box-shadow: none;
+  transition: transform 0.18s ease, border-color 0.18s ease, background 0.18s ease;
+}
+
+.mbfw-expert-modal__close:hover {
+  transform: translateY(-1px);
+  border-color: #cbd5e1;
+  background: #f8fafc;
+}
+
+.mbfw-expert-modal__close span {
+  display: block;
+  font-size: 28px;
+  line-height: 1;
+  font-weight: 400;
+  margin-top: -2px;
+}
+
+.mbfw-expert-modal__body {
+  padding: 22px;
+  background: #f8fafc;
+  flex: 1 1 auto;
+  overflow: auto;
+}
+
+.mbfw-expert-form {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.mbfw-expert-form__grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 18px;
+}
+
+.mbfw-expert-form__field--full {
+  grid-column: 1 / -1;
+}
+
+.mbfw-expert-form__label {
+  display: inline-block;
+  margin-bottom: 8px;
+  color: #111827;
+  font-size: 13px;
+  font-family: "NunitoSans-Bold", sans-serif;
+  font-weight: 700;
+}
+
+.mbfw-expert-form__required {
+  color: #dc2626;
+}
+
+.mbfw-expert-form__control {
+  width: 100%;
+  max-width: none !important;
+  min-height: 48px;
+  padding: 12px 14px;
+  border: 1px solid #d1d5db;
+  border-radius: 14px;
+  background: #fff;
+  color: #111827;
+  font-size: 14px;
+  line-height: 1.5;
+  box-shadow: none;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.mbfw-expert-form input.mbfw-expert-form__control,
+.mbfw-expert-form select.mbfw-expert-form__control,
+.mbfw-expert-form textarea.mbfw-expert-form__control {
+  max-width: none !important;
+}
+
+.mbfw-expert-form__control:hover {
+  border-color: #9ca3af;
+  background: #fff;
+}
+
+.mbfw-expert-form__control:focus {
+  outline: none;
+  border-color: #111827;
+  box-shadow: 0 0 0 3px rgba(17, 24, 39, 0.1);
+  background: #fff;
+}
+
+.mbfw-expert-form__control--textarea {
+  min-height: 140px;
+  resize: vertical;
+}
+
+.mbfw-expert-form__control--select {
+  padding-right: 42px;
+  -webkit-appearance: none;
+  appearance: none;
+  background-image: linear-gradient(45deg, transparent 50%, #6b7280 50%), linear-gradient(135deg, #6b7280 50%, transparent 50%);
+  background-position: calc(100% - 18px) calc(50% - 3px), calc(100% - 12px) calc(50% - 3px);
+  background-size: 6px 6px, 6px 6px;
+  background-repeat: no-repeat;
+}
+
+.mbfw-expert-form__checkbox-group {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.mbfw-expert-form__checkbox-label {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 12px 14px;
+  border: 1px solid #d1d5db;
+  border-radius: 14px;
+  background: #fff;
+  color: #111827;
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.mbfw-expert-form__checkbox {
+  margin: 2px 0 0;
+}
+
+.mbfw-expert-form__actions {
+  display: flex;
+  justify-content: flex-start;
+}
+
+.mbfw-expert-form__submit {
+  border: 0;
+  cursor: pointer;
+  margin-top: 0;
+}
+
+.mbfw-expert-form__submit[disabled] {
+  opacity: 0.72;
+  cursor: wait;
+}
+
+.mbfw-expert-form__status {
+  padding: 12px 14px;
+  border-radius: 14px;
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.mbfw-expert-form__status.is-success {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.mbfw-expert-form__status.is-error {
+  background: #fee2e2;
+  color: #991b1b;
+}
+
+.mbfw-expert-thank-you {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100%;
+}
+
+.mbfw-thank-you-card {
+  width: 100%;
+  max-width: 640px;
+  margin: 0 auto;
+  padding: 28px;
+  border: 1px solid #e5e7eb;
+  border-radius: 24px;
+  background: #fff;
+  text-align: center;
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.08);
+}
+
+.mbfw-thank-you-card__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 56px;
+  height: 56px;
+  margin-bottom: 14px;
+  border-radius: 999px;
+  background: #dcfce7;
+  color: #166534;
+  font-size: 28px;
+  font-weight: 700;
+}
+
+.mbfw-thank-you-card__eyebrow,
+.mbfw-thank-you-card__meta,
+.mbfw-thank-you-card__message,
+.mbfw-thank-you-card__action {
+  margin: 0;
+}
+
+.mbfw-thank-you-card__eyebrow {
+  color: #6b7280;
+  font-size: 12px;
+  font-family: "NunitoSans-Bold", sans-serif;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+
+.mbfw-thank-you-card__title {
+  margin: 10px 0 12px;
+  color: #111827;
+  font-size: 28px;
+  line-height: 1.15;
+}
+
+.mbfw-thank-you-card__message {
+  color: #111827;
+  font-size: 15px;
+  line-height: 1.7;
+}
+
+.mbfw-thank-you-card__meta {
+  margin-top: 10px;
+  color: #6b7280;
+  font-size: 13px;
+  line-height: 1.6;
+}
+
+.mbfw-thank-you-card__action {
+  margin-top: 18px;
+}
+
+body.mbfw-expert-modal-open {
+  overflow: hidden;
+}
+
+@media (max-width: 782px) {
+  .mbfw-expert-modal {
+    padding: 20px 12px;
+  }
+
+  .mbfw-expert-modal__header,
+  .mbfw-expert-modal__body {
+    padding: 18px;
+  }
+
+  .mbfw-expert-form__grid,
+  .mbfw-expert-form__checkbox-group {
+    grid-template-columns: 1fr;
+  }
+}

--- a/admin/js/mwb-admin-global-custom.js
+++ b/admin/js/mwb-admin-global-custom.js
@@ -44,7 +44,9 @@ jQuery(function ($) {
         }
     });
     if ( $('#mwb_bfwp_order_statuses_to_cancel').length > 0 ) {
-        $('#mwb_bfwp_order_statuses_to_cancel').select2();
+        $('#mwb_bfwp_order_statuses_to_cancel').select2({
+            width: '100%'
+        });
     }
     $(document).on('change', '#mwb_mbfw_cancellation_allowed', function(){
         if ( $(this).prop('checked') ) {

--- a/admin/js/mwb-bookings-for-woocommerce-admin.js
+++ b/admin/js/mwb-bookings-for-woocommerce-admin.js
@@ -52,6 +52,12 @@
       }
     );
 
+    // Update hex display when color swatch input changes
+    $(document).on('input', '.mwb-color-swatch-input', function() {
+      var hexVal = $(this).val().toUpperCase();
+      $('#' + $(this).attr('id') + '_hex_display').text(hexVal);
+    });
+
     $(".mwb-password-hidden").click(function() {
       var cur_targetEl = $(this).siblings(".mwb-form__password");
       if (cur_targetEl.attr("type") == "text") {
@@ -62,6 +68,189 @@
         cur_targetEl.attr("type", "text");
       }
     });
+
+    const expertModal = document.querySelector(".mbfw-expert-modal");
+    if (expertModal) {
+      const expertForm = expertModal.querySelector("[data-mbfw-expert-form]");
+      const expertFormPanel = expertModal.querySelector("[data-mbfw-expert-form-panel]");
+      const expertState = expertModal.querySelector("[data-mbfw-expert-state]");
+      const expertThankYou = expertModal.querySelector("[data-mbfw-expert-thank-you]");
+      const expertThankYouMessage = expertModal.querySelector("[data-mbfw-expert-thank-you-message]");
+      let expertRedirectTimeout = null;
+
+      const clearExpertStatus = function() {
+        if (!expertState) {
+          return;
+        }
+
+        expertState.hidden = true;
+        expertState.textContent = "";
+        expertState.classList.remove("is-success", "is-error");
+      };
+
+      const setExpertStatus = function(type, message) {
+        if (!expertState) {
+          return;
+        }
+
+        expertState.hidden = false;
+        expertState.textContent = message;
+        expertState.classList.remove("is-success", "is-error");
+        expertState.classList.add(type === "success" ? "is-success" : "is-error");
+      };
+
+      const clearExpertRedirect = function() {
+        if (expertRedirectTimeout) {
+          window.clearTimeout(expertRedirectTimeout);
+          expertRedirectTimeout = null;
+        }
+      };
+
+      const showExpertForm = function(clearRedirect = true) {
+        if (clearRedirect) {
+          clearExpertRedirect();
+        }
+        clearExpertStatus();
+        if (expertForm) {
+          expertForm.classList.remove("mbfw-expert-form--submitted");
+        }
+        if (expertFormPanel) {
+          expertFormPanel.hidden = false;
+        }
+        if (expertThankYou) {
+          expertThankYou.hidden = true;
+          expertThankYou.setAttribute("aria-hidden", "true");
+        }
+        if (expertThankYouMessage) {
+          expertThankYouMessage.textContent = "Thank you for submitting your request.";
+        }
+      };
+
+      const showExpertThankYou = function(message) {
+        clearExpertRedirect();
+        clearExpertStatus();
+        if (expertForm) {
+          expertForm.classList.add("mbfw-expert-form--submitted");
+        }
+        if (expertFormPanel) {
+          expertFormPanel.hidden = true;
+        }
+        if (expertThankYouMessage) {
+          expertThankYouMessage.textContent = message || "Thank you for submitting your request.";
+        }
+        if (expertThankYou) {
+          expertThankYou.hidden = false;
+          expertThankYou.setAttribute("aria-hidden", "false");
+        }
+        expertRedirectTimeout = window.setTimeout(function() {
+          window.location.href = mbfw_admin_param.reloadurl;
+        }, 4000);
+      };
+
+      const openExpertModal = function() {
+        showExpertForm();
+        expertModal.hidden = false;
+        expertModal.setAttribute("aria-hidden", "false");
+        document.body.classList.add("mbfw-expert-modal-open");
+      };
+
+      const closeExpertModal = function() {
+        expertModal.hidden = true;
+        expertModal.setAttribute("aria-hidden", "true");
+        document.body.classList.remove("mbfw-expert-modal-open");
+        showExpertForm(false);
+      };
+
+      $(document)
+        .off("click.mbfwExpertModalOpen", "[data-mbfw-open-expert-modal]")
+        .on("click.mbfwExpertModalOpen", "[data-mbfw-open-expert-modal]", function(event) {
+          event.preventDefault();
+          openExpertModal();
+        });
+
+      $(document)
+        .off("click.mbfwExpertModalClose", "[data-mbfw-close-expert-modal]")
+        .on("click.mbfwExpertModalClose", "[data-mbfw-close-expert-modal]", function(event) {
+          event.preventDefault();
+          closeExpertModal();
+        });
+
+      $(document)
+        .off("keydown.mbfwExpertModal")
+        .on("keydown.mbfwExpertModal", function(event) {
+          if (event.key === "Escape" && !expertModal.hidden) {
+            closeExpertModal();
+          }
+        });
+
+      $(document)
+        .off("submit.mbfwExpertForm", "[data-mbfw-expert-form]")
+        .on("submit.mbfwExpertForm", "[data-mbfw-expert-form]", function(event) {
+          const formElement = this;
+          const submitButton = formElement.querySelector("[data-mbfw-expert-submit]");
+          const formData = new FormData(formElement);
+          const payload = {};
+
+          event.preventDefault();
+          clearExpertStatus();
+
+          formData.forEach(function(value, key) {
+            const normalizedKey = key.replace(/\[\]$/, "");
+
+            if (Object.prototype.hasOwnProperty.call(payload, normalizedKey)) {
+              if (!Array.isArray(payload[normalizedKey])) {
+                const currentValue = payload[normalizedKey];
+                payload[normalizedKey] = [];
+                payload[normalizedKey].push(currentValue);
+              }
+              payload[normalizedKey].push(value);
+              return;
+            }
+
+            payload[normalizedKey] = value;
+          });
+
+          if (submitButton) {
+            submitButton.disabled = true;
+            submitButton.textContent = submitButton.getAttribute("data-mbfw-submit-loading-label") || "Sending...";
+          }
+
+          $.ajax({
+            url: mbfw_admin_param.ajaxurl,
+            method: "POST",
+            dataType: "json",
+            data: {
+              action: "mwb_mbfw_submit_talk_to_expert",
+              nonce: mbfw_admin_param.talk_to_expert_nonce,
+              form_data: JSON.stringify(payload),
+            },
+          })
+            .done(function(response) {
+              const message = response && response.data && response.data.message ? response.data.message : "Thank you for submitting your request.";
+
+              if (response && response.success) {
+                formElement.reset();
+                showExpertThankYou(message);
+                return;
+              }
+
+              setExpertStatus("error", message);
+            })
+            .fail(function(xhr) {
+              const message = xhr && xhr.responseJSON && xhr.responseJSON.data && xhr.responseJSON.data.message
+                ? xhr.responseJSON.data.message
+                : "Something went wrong while submitting the form. Please try again.";
+
+              setExpertStatus("error", message);
+            })
+            .always(function() {
+              if (submitButton) {
+                submitButton.disabled = false;
+                submitButton.textContent = submitButton.getAttribute("data-mbfw-submit-label") || "Submit Request";
+              }
+            });
+        });
+    }
   });
 
   $(window).load(function() {

--- a/admin/partials/mwb-bookings-for-woocommerce-admin-dashboard.php
+++ b/admin/partials/mwb-bookings-for-woocommerce-admin-dashboard.php
@@ -36,11 +36,12 @@ $mbfw_default_tabs = $mbfw_mwb_mbfw_obj->mwb_mbfw_plug_default_tabs();
 		do_action( 'mwb_mbfw_settings_saved_notice' );
 	?>
 	<div class="mwb-header-container mwb-bg-white mwb-r-8">
-		<h1 class="mwb-header-title">
-			<?php
-			$plugin_name = "Wps Bookings For Woocommerce";
-			echo esc_attr(
-				strtoupper(
+		<div class="mwb-header-branding">
+			<span class="mwb-header-badge"><?php esc_html_e( 'Free Active', 'mwb-bookings-for-woocommerce' ); ?></span>
+			<h1 class="mwb-header-title">
+				<?php
+				$plugin_name = "WPS Bookings For WooCommerce";
+				echo esc_html(
 					str_replace(
 						'-',
 						' ',
@@ -51,41 +52,15 @@ $mbfw_default_tabs = $mbfw_mwb_mbfw_obj->mwb_mbfw_plug_default_tabs();
 						 */
 						apply_filters( 'mwb_mbfw_update_plugin_name_from_pro', $plugin_name )
 					)
-				)
-			);
-			?>
-		</h1>
-		<a href="
-		<?php
-		$doc_link = 'https://docs.wpswings.com/bookings-for-woocommerce/?utm_source=wpswings-bookings-doc&utm_medium=bookings-org-backend&utm_campaign=documentation';
-		echo esc_url(
-			/**
-			 * Filter is for returning something.
-			 *
-			 * @since 1.0.0
-			 */
-			apply_filters( 'mwb_mbfw_update_doc_link', $doc_link )
-		);
-		?>
-		" target="_blank" class="mwb-link"><?php esc_html_e( 'Documentation', 'mwb-bookings-for-woocommerce' ); ?></a>
-		<span>|</span>
-		<a href="
-		<?php
-		$query_link = 'https://wpswings.com/submit-query/?utm_source=wpswings-bookings-support&utm_medium=bookings-org-backend&utm_campaign=support';
-		echo esc_url(
-			/**
-			 * Filter is for returning something.
-			 *
-			 * @since 1.0.0
-			 */
-			apply_filters( 'mwb_mbfw_update_query_link', $query_link )
-		);
-		?>
-		" target="_blank" class="mwb-link"><?php esc_html_e( 'Support', 'mwb-bookings-for-woocommerce' ); ?></a>
+				);
+				?>
+			</h1>
+		</div>
 	</div>
 </header>
 <main class="mwb-main mwb-bg-white mwb-r-8">
 	<nav class="mwb-navbar">
+		<span class="mwb-navbar__version">v<?php echo esc_html( MWB_BOOKINGS_FOR_WOOCOMMERCE_VERSION ); ?></span>
 		<ul class="mwb-navbar__items">
 			<?php
 			if ( is_array( $mbfw_default_tabs ) && ! empty( $mbfw_default_tabs ) ) {
@@ -105,40 +80,201 @@ $mbfw_default_tabs = $mbfw_mwb_mbfw_obj->mwb_mbfw_plug_default_tabs();
 			?>
 		</ul>
 	</nav>
-	<section class="mwb-section">
-		<div>
-			<?php
-			/**
-			 * Filter is for returning something.
-			 *
-			 * @since 1.0.0
-			 */
-			do_action( 'mwb_mbfw_before_general_settings_form' );
-			// if submenu is directly clicked on woocommerce.
-			if ( empty( $mbfw_active_tab ) ) {
-				$mbfw_active_tab = 'mwb-bookings-for-woocommerce-general';
-			}
+	<div class="mwb-dashboard-body">
+		<section class="mwb-section">
+			<div>
+				<?php
+				/**
+				 * Filter is for returning something.
+				 *
+				 * @since 1.0.0
+				 */
+				do_action( 'mwb_mbfw_before_general_settings_form' );
+				// if submenu is directly clicked on woocommerce.
+				if ( empty( $mbfw_active_tab ) ) {
+					$mbfw_active_tab = 'mwb-bookings-for-woocommerce-general';
+				}
 
-			// Look for the path based on the tab id in the admin templates.
-			$mbfw_default_tabs = $mbfw_mwb_mbfw_obj->mwb_mbfw_plug_default_tabs();
+				// Look for the path based on the tab id in the admin templates.
+				$mbfw_default_tabs = $mbfw_mwb_mbfw_obj->mwb_mbfw_plug_default_tabs();
 
-			// Check if the key exists before accessing it.
-			if ( isset( $mbfw_default_tabs[ $mbfw_active_tab ]['file_path'] ) ) {
-				$mbfw_tab_content_path = $mbfw_default_tabs[ $mbfw_active_tab ]['file_path'];
-				$mbfw_mwb_mbfw_obj->mwb_mbfw_plug_load_template( $mbfw_tab_content_path );
-			} else {
-				// Handle the case where the key does not exist.
-				// You might want to set a default value or display an error message.
-				$mbfw_tab_content_path = $mbfw_default_tabs['mwb-bookings-for-woocommerce-general']['file_path'];
-				$mbfw_mwb_mbfw_obj->mwb_mbfw_plug_load_template( $mbfw_tab_content_path );
-			}
-			/**
-			 * Filter is for returning something.
-			 *
-			 * @since 1.0.0
-			 */
-			do_action( 'mwb_mbfw_after_general_settings_form' );
-			?>
-		</div>
-	</section>
+				// Per-tab highlight block content.
+				$mbfw_tab_highlights = array(
+					'mwb-bookings-for-woocommerce-overview'                      => array(
+						'category'    => esc_html__( 'PLUGIN GUIDE', 'mwb-bookings-for-woocommerce' ),
+						'title'       => esc_html__( 'Overview', 'mwb-bookings-for-woocommerce' ),
+						'description' => esc_html__( 'Get a quick tour of all features and capabilities of WPS Bookings for WooCommerce.', 'mwb-bookings-for-woocommerce' ),
+						'doc_url'     => 'https://docs.wpswings.com/bookings-for-woocommerce/',
+					),
+					'mwb-bookings-for-woocommerce-general'                       => array(
+						'category'    => esc_html__( 'PLUGIN SETTINGS', 'mwb-bookings-for-woocommerce' ),
+						'title'       => esc_html__( 'General Settings', 'mwb-bookings-for-woocommerce' ),
+						'description' => esc_html__( 'Configure core plugin settings including enabling bookings and managing global preferences.', 'mwb-bookings-for-woocommerce' ),
+						'doc_url'     => 'https://docs.wpswings.com/bookings-for-woocommerce/',
+					),
+					'mwb-bookings-for-woocommerce-configuration'                 => array(
+						'category'    => esc_html__( 'BOOKING SETUP', 'mwb-bookings-for-woocommerce' ),
+						'title'       => esc_html__( 'Configuration Settings', 'mwb-bookings-for-woocommerce' ),
+						'description' => esc_html__( 'Set up booking forms, additional costs, people types, and other configuration options.', 'mwb-bookings-for-woocommerce' ),
+						'doc_url'     => 'https://docs.wpswings.com/bookings-for-woocommerce/',
+					),
+					'mwb-bookings-for-woocommerce-booking-calendar-listing'      => array(
+						'category'    => esc_html__( 'CALENDAR VIEW', 'mwb-bookings-for-woocommerce' ),
+						'title'       => esc_html__( 'Bookings Calendar', 'mwb-bookings-for-woocommerce' ),
+						'description' => esc_html__( 'View and manage all your bookings in an interactive calendar or list layout.', 'mwb-bookings-for-woocommerce' ),
+						'doc_url'     => 'https://docs.wpswings.com/bookings-for-woocommerce/',
+					),
+					'mwb-bookings-for-woocommerce-booking-availability-settings' => array(
+						'category'    => esc_html__( 'AVAILABILITY', 'mwb-bookings-for-woocommerce' ),
+						'title'       => esc_html__( 'Availability Settings', 'mwb-bookings-for-woocommerce' ),
+						'description' => esc_html__( 'Define global availability rules, blocked dates, and booking time windows.', 'mwb-bookings-for-woocommerce' ),
+						'doc_url'     => 'https://docs.wpswings.com/bookings-for-woocommerce/',
+					),
+				);
 
+				// Allow pro / other plugins to register highlight data for their tabs.
+				$mbfw_tab_highlights = apply_filters( 'mwb_mbfw_tab_highlight_data', $mbfw_tab_highlights );
+
+				// Resolve block data: use explicit entry if available, otherwise auto-generate from tab title.
+				if ( isset( $mbfw_tab_highlights[ $mbfw_active_tab ] ) ) {
+					$mbfw_block = $mbfw_tab_highlights[ $mbfw_active_tab ];
+				} elseif ( isset( $mbfw_default_tabs[ $mbfw_active_tab ]['title'] ) ) {
+					$mbfw_block = array(
+						'category'    => esc_html__( 'SETTINGS', 'mwb-bookings-for-woocommerce' ),
+						'title'       => $mbfw_default_tabs[ $mbfw_active_tab ]['title'],
+						'description' => '',
+						'doc_url'     => 'https://docs.wpswings.com/bookings-for-woocommerce/',
+					);
+				} else {
+					$mbfw_block = null;
+				}
+
+				if ( $mbfw_block ) {
+					?>
+					<div class="wps-tab-highlight-block">
+						<div class="wps-tab-highlight-block__left">
+							<span class="wps-tab-highlight-block__category"><?php echo esc_html( $mbfw_block['category'] ); ?></span>
+							<h2 class="wps-tab-highlight-block__title"><?php echo esc_html( $mbfw_block['title'] ); ?></h2>
+							<?php if ( ! empty( $mbfw_block['description'] ) ) : ?>
+								<p class="wps-tab-highlight-block__desc"><?php echo esc_html( $mbfw_block['description'] ); ?></p>
+							<?php endif; ?>
+						</div>
+						<a href="<?php echo esc_url( $mbfw_block['doc_url'] ); ?>" target="_blank" class="wps-tab-highlight-block__btn">
+							<?php esc_html_e( 'Read Documentation', 'mwb-bookings-for-woocommerce' ); ?>
+						</a>
+					</div>
+					<?php
+				}
+
+				// Check if the key exists before accessing it.
+				if ( isset( $mbfw_default_tabs[ $mbfw_active_tab ]['file_path'] ) ) {
+					$mbfw_tab_content_path = $mbfw_default_tabs[ $mbfw_active_tab ]['file_path'];
+					$mbfw_mwb_mbfw_obj->mwb_mbfw_plug_load_template( $mbfw_tab_content_path );
+				} else {
+					// Handle the case where the key does not exist.
+					// You might want to set a default value or display an error message.
+					$mbfw_tab_content_path = $mbfw_default_tabs['mwb-bookings-for-woocommerce-general']['file_path'];
+					$mbfw_mwb_mbfw_obj->mwb_mbfw_plug_load_template( $mbfw_tab_content_path );
+				}
+				/**
+				 * Filter is for returning something.
+				 *
+				 * @since 1.0.0
+				 */
+				do_action( 'mwb_mbfw_after_general_settings_form' );
+				?>
+			</div>
+		</section>
+
+		<!-- Sidebar -->
+		<aside class="wps-dashboard-sidebar">
+
+			<!-- Need help -->
+			<div class="wps-sidebar-card">
+				<h3 class="wps-sidebar-card__title"><?php esc_html_e( 'Need help with this plugin?', 'mwb-bookings-for-woocommerce' ); ?></h3>
+				<a href="https://www.youtube.com/channel/UCqCOG8Dk6EAeJlTWkjekifg" target="_blank" class="wps-sidebar-card__link">
+					<?php esc_html_e( 'Watch Video', 'mwb-bookings-for-woocommerce' ); ?>
+				</a>
+				<a href="https://docs.wpswings.com/bookings-for-woocommerce/" target="_blank" class="wps-sidebar-card__link">
+					<?php esc_html_e( 'Documentation', 'mwb-bookings-for-woocommerce' ); ?>
+				</a>
+				<a href="https://wpswings.com/submit-query/" target="_blank" class="wps-sidebar-card__link">
+					<?php esc_html_e( 'Support', 'mwb-bookings-for-woocommerce' ); ?>
+				</a>
+			</div>
+
+			<!-- Grow Your Store -->
+			<div class="wps-sidebar-card">
+				<div class="wps-sidebar-card__grow-header">
+					<div>
+						<h3 class="wps-sidebar-card__title"><?php esc_html_e( 'Grow Your Store With WP Swings', 'mwb-bookings-for-woocommerce' ); ?></h3>
+						<p class="wps-sidebar-card__subtitle"><?php esc_html_e( 'Expert solutions to boost your store\'s performance.', 'mwb-bookings-for-woocommerce' ); ?></p>
+					</div>
+					<span class="wps-sidebar-card__star">&#9733;</span>
+				</div>
+				<a href="https://wpswings.com/seo-services/" target="_blank" class="wps-sidebar-card__service-link">
+					<div class="wps-sidebar-card__service-icon wps-sidebar-card__service-icon--search">
+						<span class="material-icons">search</span>
+					</div>
+					<div>
+						<p class="wps-sidebar-card__service-name"><?php esc_html_e( 'SEO Services', 'mwb-bookings-for-woocommerce' ); ?></p>
+						<p class="wps-sidebar-card__service-desc"><?php esc_html_e( 'Improve rankings & organic traffic', 'mwb-bookings-for-woocommerce' ); ?></p>
+					</div>
+					<span class="material-icons wps-sidebar-card__chevron">chevron_right</span>
+				</a>
+				<a href="https://wpswings.com/google-ads/" target="_blank" class="wps-sidebar-card__service-link">
+					<div class="wps-sidebar-card__service-icon wps-sidebar-card__service-icon--ads">
+						<span class="material-icons">north_east</span>
+					</div>
+					<div>
+						<p class="wps-sidebar-card__service-name"><?php esc_html_e( 'Google Ads Setup And G4 Setup', 'mwb-bookings-for-woocommerce' ); ?></p>
+						<p class="wps-sidebar-card__service-desc"><?php esc_html_e( 'Run profitable ad campaigns', 'mwb-bookings-for-woocommerce' ); ?></p>
+					</div>
+					<span class="material-icons wps-sidebar-card__chevron">chevron_right</span>
+				</a>
+				<a href="https://wpswings.com/speed-optimization/" target="_blank" class="wps-sidebar-card__service-link">
+					<div class="wps-sidebar-card__service-icon wps-sidebar-card__service-icon--speed">
+						<span class="material-icons">speed</span>
+					</div>
+					<div>
+						<p class="wps-sidebar-card__service-name"><?php esc_html_e( 'Speed Optimization', 'mwb-bookings-for-woocommerce' ); ?></p>
+						<p class="wps-sidebar-card__service-desc"><?php esc_html_e( 'Faster site, happier customers', 'mwb-bookings-for-woocommerce' ); ?></p>
+					</div>
+					<span class="material-icons wps-sidebar-card__chevron">chevron_right</span>
+				</a>
+				<a href="https://wpswings.com/woocommerce-development/" target="_blank" class="wps-sidebar-card__service-link">
+					<div class="wps-sidebar-card__service-icon wps-sidebar-card__service-icon--dev">
+						<span class="wps-woo-icon"></span>
+					</div>
+					<div>
+						<p class="wps-sidebar-card__service-name"><?php esc_html_e( 'WooCommerce Development Services', 'mwb-bookings-for-woocommerce' ); ?></p>
+						<p class="wps-sidebar-card__service-desc"><?php esc_html_e( 'Custom solution for your store needs', 'mwb-bookings-for-woocommerce' ); ?></p>
+					</div>
+					<span class="material-icons wps-sidebar-card__chevron">chevron_right</span>
+				</a>
+				<a href="#" class="wps-sidebar-card__expert-btn" data-mbfw-open-expert-modal="true">
+					<?php esc_html_e( 'Talk to an Expert', 'mwb-bookings-for-woocommerce' ); ?>
+				</a>
+				<p class="wps-sidebar-card__services-by"><?php esc_html_e( 'Services by WP Swings', 'mwb-bookings-for-woocommerce' ); ?> &#128578;</p>
+			</div>
+
+			<!-- Still facing problems -->
+			<div class="wps-sidebar-card">
+				<h3 class="wps-sidebar-card__title"><?php esc_html_e( 'Still facing problems?', 'mwb-bookings-for-woocommerce' ); ?></h3>
+				<p class="wps-sidebar-card__subtitle"><?php esc_html_e( 'We are ready to resolve workflow, styling, and integration issues across your store setup.', 'mwb-bookings-for-woocommerce' ); ?></p>
+				<a href="https://wpswings.com/submit-query/" target="_blank" class="wps-sidebar-card__dark-btn">
+					<?php esc_html_e( 'Contact Us', 'mwb-bookings-for-woocommerce' ); ?>
+				</a>
+			</div>
+
+			<!-- Explore more plugins -->
+			<div class="wps-sidebar-card">
+				<h3 class="wps-sidebar-card__title"><?php esc_html_e( 'Explore more plugins', 'mwb-bookings-for-woocommerce' ); ?></h3>
+				<p class="wps-sidebar-card__subtitle"><?php esc_html_e( 'Discover additional commerce and automation plugins from the same product family.', 'mwb-bookings-for-woocommerce' ); ?></p>
+				<a href="https://wpswings.com/woocommerce-plugins/" target="_blank" class="wps-sidebar-card__outline-btn">
+					<?php esc_html_e( 'View More Plugins', 'mwb-bookings-for-woocommerce' ); ?>
+				</a>
+			</div>
+
+		</aside>
+	</div>

--- a/admin/partials/mwb-bookings-for-woocommerce-booking-calendar-listing.php
+++ b/admin/partials/mwb-bookings-for-woocommerce-booking-calendar-listing.php
@@ -56,7 +56,7 @@ if ( in_array( 'bookings-for-woocommerce-pro/bookings-for-woocommerce-pro.php', 
 			
 		
 		<div class="wps_sub_main_wrapper">
-			<select name="wps_order_status" id="wps_order_status" class="wps_order_status_">
+			<select name="wps_order_status" id="wps_order_status" class="wps_order_status_ wps-calendar-filter-select">
 				<?php foreach ( $order_status as $value => $label ) : ?>
 					<option value="<?php echo esc_attr( $value ); ?>" <?php echo ( 'select' == $value ) ? 'selected' : ''; ?>>
 					<?php echo esc_attr( $label ); ?>
@@ -65,8 +65,8 @@ if ( in_array( 'bookings-for-woocommerce-pro/bookings-for-woocommerce-pro.php', 
 		
 			
 		</div>		
-		<input type="button" class="button" name="wps_mbfw_filter_calender" id="wps_mbfw_filter_calender" value="<?php esc_html_e( 'Filter', 'mwb-bookings-for-woocommerce' ); ?>">
-		<input type="button" class="button" name="wps_mbfw_clear_calender" id="wps_mbfw_clear_calender" value="<?php esc_html_e( 'Clear', 'mwb-bookings-for-woocommerce' ); ?>">
+		<input type="button" class="button wps-calendar-action-btn wps-calendar-action-btn--primary" name="wps_mbfw_filter_calender" id="wps_mbfw_filter_calender" value="<?php esc_html_e( 'Filter', 'mwb-bookings-for-woocommerce' ); ?>">
+		<input type="button" class="button wps-calendar-action-btn wps-calendar-action-btn--secondary" name="wps_mbfw_clear_calender" id="wps_mbfw_clear_calender" value="<?php esc_html_e( 'Clear', 'mwb-bookings-for-woocommerce' ); ?>">
 		<?php wp_nonce_field( 'admin_calender_data', 'mwb_calender_nonce' ); ?>
 		
 	</div>

--- a/admin/partials/mwb-bookings-for-woocommerce-configuration.php
+++ b/admin/partials/mwb-bookings-for-woocommerce-configuration.php
@@ -44,7 +44,7 @@ global $mbfw_mwb_mbfw_obj;
 			foreach ( $mwb_bfw_taxonomies_array as $key => $taxonomy_slug ) {
 				$mwb_taxonomy       = get_taxonomy( $taxonomy_slug );
 				$mwb_name           = $mwb_taxonomy->label;
-				$mwb_active_sub_tab = $mwb_bfw_active_sub_tab === $taxonomy_slug ? 'nav-tab-active' : '';
+				$mwb_active_sub_tab = $active_sub_tab === $taxonomy_slug ? 'nav-tab-active' : '';
 				echo "<a href='admin.php?page=mwb_bookings_for_woocommerce_menu&mbfw_tab=mwb-bookings-for-woocommerce-configuration&bfw_sub_nav=" . esc_attr( $taxonomy_slug ) . "' class='nav-tab " . esc_attr( $mwb_active_sub_tab ) . " mwb-bfw-nav-tab'>" . esc_attr( $mwb_name ) . '</a>';
 			}
 
@@ -53,9 +53,12 @@ global $mbfw_mwb_mbfw_obj;
 
 			<?php
 			if ( in_array( $active_sub_tab, $mwb_bfw_taxonomies_array, true ) ) {
-				$url = admin_url( "edit-tags.php?taxonomy=$active_sub_tab" );
-				wp_safe_redirect( $url );
-				exit;
+				echo '<section class="mwb-section">';
+				echo '<div>';
+				$taxonomy = $active_sub_tab; // phpcs:ignore WordPress.WP.GlobalVariablesOverride
+				include MWB_BOOKINGS_FOR_WOOCOMMERCE_DIR_PATH . 'admin/partials/mwb-bookings-for-woocommerce-taxonomy-inline.php';
+				echo '</div></section>';
+				
 			} elseif ( array_key_exists( $active_sub_tab, $mwb_bfw_sub_tabs_array ) ) {
 				echo '<section class="mwb-section">';
 				echo '<div>';

--- a/admin/partials/mwb-bookings-for-woocommerce-overview.php
+++ b/admin/partials/mwb-bookings-for-woocommerce-overview.php
@@ -22,130 +22,99 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 do_action( 'mwb_mbfw_overview_content_top' );
 ?>
-<div class="mwb-overview__wrapper">
-	<div class="mwb-overview__banner">
-		<img src="<?php echo esc_html( MWB_BOOKINGS_FOR_WOOCOMMERCE_DIR_URL ); ?>admin/image/Banner-image.jpg" alt="Overview banner image">
-	</div>
-	<div class="mwb-overview__content">
-		<div class="mwb-overview__content-description">
-			<h2><?php esc_html_e( 'What is Bookings for WooCommerce?', 'mwb-bookings-for-woocommerce' ); ?></h2>
-			<p>
-				<?php
-				esc_html_e(
-					'Bookings for WooCommerce is a sophisticated plugin that lets online retailers create an online booking system and easily transform their merchandise into online booking solutions and make them accessible to their customers for a particular time frame.
-					This plugin is simple yet powerful because it is a one-stop medium to offer online booking solutions for nearly all types of businesses. You can use it to book a hotel room, rent a product, reserve a course or class, sell a tour package online, buy an event ticket,
-					schedule an appointment, and many other things.',
-					'mwb-bookings-for-woocommerce'
-				);
-				?>
-			</p>
-			<h3><?php esc_html_e( 'As a Store Owner, you can-', 'mwb-bookings-for-woocommerce' ); ?></h3>
-			<ul class="mwb-overview__features">
-				<li><?php esc_html_e( 'With ease, create an unlimited number of online booking solutions.', 'mwb-bookings-for-woocommerce' ); ?></li>
-				<li><?php esc_html_e( 'Define the maximum number of bookings per day or per user with ease.', 'mwb-bookings-for-woocommerce' ); ?></li>
-				<li><?php esc_html_e( 'Can offer easy booking management parameters from the backend i.e. admin area.', 'mwb-bookings-for-woocommerce' ); ?></li>
-				<li><?php esc_html_e( 'Confirm the booking requests made by the customers.', 'mwb-bookings-for-woocommerce' ); ?></li>
-				<li><?php esc_html_e( 'Easy cancellation is allowed for booking orders.', 'mwb-bookings-for-woocommerce' ); ?></li>
-				<li><?php esc_html_e( 'Can easily define their offered WooCommerce booking services and additional costs.', 'mwb-bookings-for-woocommerce' ); ?></li>
-			</ul>
+<div class="wps-overview-wrap">
+
+	<!-- Hero Section -->
+	<div class="wps-overview-hero">
+		<div class="wps-overview-hero__icon">
+			<span class="material-icons">event_available</span>
 		</div>
-		<h2> <?php esc_html_e( 'The Free Plugin Benefits include-', 'mwb-bookings-for-woocommerce' ); ?></h2>
-		<div class="mwb-overview__keywords">
-			<div class="mwb-overview__keywords-item">
-				<div class="mwb-overview__keywords-card">
-					<div class="mwb-overview__keywords-image">
-						<img src="<?php echo esc_html( MWB_BOOKINGS_FOR_WOOCOMMERCE_DIR_URL . 'admin/image/Adaptable-Bookings.png' ); ?>" alt="Advanced-report image">
-					</div>
-					<div class="mwb-overview__keywords-text">
-						<h3 class="mwb-overview__keywords-heading"><?php esc_html_e( 'Adaptable Bookings', 'mwb-bookings-for-woocommerce' ); ?></h3>
-						<p class="mwb-overview__keywords-description">
-							<?php
-							esc_html_e( 'Customers can personalize their booking criteria to fit their budget, event, and needs. You may make bookings without having to make a phone call, allowing you to do it from the convenience of your own home offering all WooCommerce easy booking services.', 'mwb-bookings-for-woocommerce' );
-							?>
-						</p>
-					</div>
+		<p class="wps-overview-hero__label"><?php esc_html_e( 'OVERVIEW', 'mwb-bookings-for-woocommerce' ); ?></p>
+		<h1 class="wps-overview-hero__title"><?php esc_html_e( 'WPS Bookings For WooCommerce', 'mwb-bookings-for-woocommerce' ); ?></h1>
+		<p class="wps-overview-hero__desc">
+			<?php esc_html_e( 'Transform your WooCommerce products into bookable services — appointments, rentals, events, and more — all managed from one powerful dashboard.', 'mwb-bookings-for-woocommerce' ); ?>
+		</p>
+	</div>
+
+	<!-- Features Section -->
+	<div class="wps-overview-features">
+		<h2 class="wps-overview-features__title"><?php esc_html_e( 'Top Features of this plugin', 'mwb-bookings-for-woocommerce' ); ?></h2>
+		<div class="wps-overview-features__grid">
+
+			<div class="wps-overview-feature-card">
+				<div class="wps-overview-feature-card__icon">
+					<span class="material-icons">tune</span>
 				</div>
+				<h3 class="wps-overview-feature-card__title"><?php esc_html_e( 'Adaptable Bookings', 'mwb-bookings-for-woocommerce' ); ?></h3>
+				<p class="wps-overview-feature-card__desc">
+					<?php esc_html_e( 'Customers can personalise their booking criteria to fit their budget, event, and needs — all without making a phone call.', 'mwb-bookings-for-woocommerce' ); ?>
+				</p>
 			</div>
-			<div class="mwb-overview__keywords-item">
-				<div class="mwb-overview__keywords-card">
-					<div class="mwb-overview__keywords-image">
-						<img src="<?php echo esc_html( MWB_BOOKINGS_FOR_WOOCOMMERCE_DIR_URL . 'admin/image/Availability-Settings-to-Offer-Bookings.png' ); ?>" alt="Workflow image">
-					</div>
-					<div class="mwb-overview__keywords-text">
-						<h3 class="mwb-overview__keywords-heading"><?php esc_html_e( 'Availability Settings to Offer Bookings', 'mwb-bookings-for-woocommerce' ); ?></h3>
-						<p class="mwb-overview__keywords-description">
-							<?php
-							esc_html_e( 'Admin managers may quickly specify booking availability for the day, as well as the exact deadline for booking online. They only need to change the timeframe in the Availability tab of the plugin General Settings area to perform easy booking management.', 'mwb-bookings-for-woocommerce' );
-							?>
-						</p>
-					</div>
+
+			<div class="wps-overview-feature-card">
+				<div class="wps-overview-feature-card__icon">
+					<span class="material-icons">date_range</span>
 				</div>
+				<h3 class="wps-overview-feature-card__title"><?php esc_html_e( 'Availability Settings', 'mwb-bookings-for-woocommerce' ); ?></h3>
+				<p class="wps-overview-feature-card__desc">
+					<?php esc_html_e( 'Quickly define booking availability windows and deadlines by adjusting the timeframe in the Availability Settings tab.', 'mwb-bookings-for-woocommerce' ); ?>
+				</p>
 			</div>
-			<div class="mwb-overview__keywords-item">
-				<div class="mwb-overview__keywords-card">
-					<div class="mwb-overview__keywords-image">
-						<img src="<?php echo esc_html( MWB_BOOKINGS_FOR_WOOCOMMERCE_DIR_URL . 'admin/image/Ease-of-Setting-a-Booking-Calendar.png' ); ?>" alt="Variable product image">
-					</div>
-					<div class="mwb-overview__keywords-text">
-						<h3 class="mwb-overview__keywords-heading"><?php esc_html_e( 'Ease of Setting a Booking Calendar', 'mwb-bookings-for-woocommerce' ); ?></h3>
-						<p class="mwb-overview__keywords-description">
-							<?php
-							esc_html_e( 'Merchants can use the WooCommerce Calendar Booking display listing to build and monitor how their day or month is performing. They can also adjust current bookings or availability with response to easy booking management.', 'mwb-bookings-for-woocommerce' );
-							?>
-						</p>
-					</div>
+
+			<div class="wps-overview-feature-card">
+				<div class="wps-overview-feature-card__icon">
+					<span class="material-icons">calendar_month</span>
 				</div>
+				<h3 class="wps-overview-feature-card__title"><?php esc_html_e( 'Booking Calendar View', 'mwb-bookings-for-woocommerce' ); ?></h3>
+				<p class="wps-overview-feature-card__desc">
+					<?php esc_html_e( 'Use the Calendar display listing to build and monitor daily or monthly performance and adjust bookings with ease.', 'mwb-bookings-for-woocommerce' ); ?>
+				</p>
 			</div>
-			<div class="mwb-overview__keywords-item">
-				<div class="mwb-overview__keywords-card">
-					<div class="mwb-overview__keywords-image">
-						<img src="<?php echo esc_html( MWB_BOOKINGS_FOR_WOOCOMMERCE_DIR_URL . 'admin/image/Subtly-Stress-Additional-Costs-On-Demand-Surge.png' ); ?>" alt="Variable product image">
-					</div>
-					<div class="mwb-overview__keywords-text">
-						<h3 class="mwb-overview__keywords-heading"><?php esc_html_e( 'Subtly Stress Additional Costs On Demand Surge', 'mwb-bookings-for-woocommerce' ); ?></h3>
-						<p class="mwb-overview__keywords-description">
-							<?php
-							esc_html_e( 'An increase in demand can have a direct impact on the price of bookable products. When there is a significant demand for certain online booking solutions in a given location, admin administrators can easily set up WooCommerce bookings based on additional expenses.', 'mwb-bookings-for-woocommerce' );
-							?>
-						</p>
-					</div>
+
+			<div class="wps-overview-feature-card">
+				<div class="wps-overview-feature-card__icon">
+					<span class="material-icons">attach_money</span>
 				</div>
+				<h3 class="wps-overview-feature-card__title"><?php esc_html_e( 'Demand-Based Pricing', 'mwb-bookings-for-woocommerce' ); ?></h3>
+				<p class="wps-overview-feature-card__desc">
+					<?php esc_html_e( 'Set additional costs on bookable products when demand surges, giving you full control over dynamic pricing.', 'mwb-bookings-for-woocommerce' ); ?>
+				</p>
 			</div>
-			<div class="mwb-overview__keywords-item">
-				<div class="mwb-overview__keywords-card">
-					<div class="mwb-overview__keywords-image">
-						<img src="<?php echo esc_html( MWB_BOOKINGS_FOR_WOOCOMMERCE_DIR_URL . 'admin/image/Set-Forth-Booking-Limits-For-Day.png' ); ?>" alt="Variable product image">
-					</div>
-					<div class="mwb-overview__keywords-text">
-						<h3 class="mwb-overview__keywords-heading"><?php esc_html_e( 'Set-Forth Booking Limits For Day', 'mwb-bookings-for-woocommerce' ); ?></h3>
-						<p class="mwb-overview__keywords-description">
-							<?php
-							esc_html_e( 'To avoid being overbooked, store managers can set a maximum number of bookings per user for bookable products, as well as provide easy booking management and effective tracking.', 'mwb-bookings-for-woocommerce' );
-							?>
-						</p>
-					</div>
+
+			<div class="wps-overview-feature-card">
+				<div class="wps-overview-feature-card__icon">
+					<span class="material-icons">format_list_numbered</span>
 				</div>
+				<h3 class="wps-overview-feature-card__title"><?php esc_html_e( 'Booking Limits Per Day', 'mwb-bookings-for-woocommerce' ); ?></h3>
+				<p class="wps-overview-feature-card__desc">
+					<?php esc_html_e( 'Prevent overbooking by setting a maximum number of bookings per user per day for any bookable product.', 'mwb-bookings-for-woocommerce' ); ?>
+				</p>
 			</div>
-			<div class="mwb-overview__keywords-item">
-				<div class="mwb-overview__keywords-card">
-					<div class="mwb-overview__keywords-image">
-						<img src="<?php echo esc_html( MWB_BOOKINGS_FOR_WOOCOMMERCE_DIR_URL . 'admin/image/Easy-Booking-Cancellation-and-Confirmations.png' ); ?>" alt="Variable product image">
-					</div>
-					<div class="mwb-overview__keywords-text">
-						<h3 class="mwb-overview__keywords-heading"><?php esc_html_e( 'Easy Booking Cancellation', 'mwb-bookings-for-woocommerce' ); ?></h3>
-						<p class="mwb-overview__keywords-description">
-							<?php
-							esc_html_e(
-								'Admin managers can now effortlessly offer easy booking cancellation for the booking requests by the customers making use of the plugin features. 
-								In order to utilize the feature, the administrator needs to turn ON the toggle for Cancellation Allowed settings available in the specified booking
-								product setting and specify the Order Statuses for the same.',
-								'mwb-bookings-for-woocommerce'
-							);
-							?>
-						</p>
-					</div>
+
+			<div class="wps-overview-feature-card">
+				<div class="wps-overview-feature-card__icon">
+					<span class="material-icons">cancel</span>
 				</div>
+				<h3 class="wps-overview-feature-card__title"><?php esc_html_e( 'Easy Booking Cancellation', 'mwb-bookings-for-woocommerce' ); ?></h3>
+				<p class="wps-overview-feature-card__desc">
+					<?php esc_html_e( 'Enable cancellations effortlessly by turning on the Cancellation Allowed toggle in your booking product settings.', 'mwb-bookings-for-woocommerce' ); ?>
+				</p>
 			</div>
+
 		</div>
 	</div>
+
+	<!-- Footer CTA -->
+	<div class="wps-overview-cta">
+		<div class="wps-overview-cta__text">
+			<p class="wps-overview-cta__heading"><?php esc_html_e( 'Facing issues?', 'mwb-bookings-for-woocommerce' ); ?></p>
+			<p class="wps-overview-cta__sub"><?php esc_html_e( 'We are ready to resolve your problems.', 'mwb-bookings-for-woocommerce' ); ?></p>
+		</div>
+		<div class="wps-overview-cta__actions">
+			<a href="https://wpswings.com/submit-query/" target="_blank" class="wps-overview-cta__btn"><?php esc_html_e( 'Contact us!', 'mwb-bookings-for-woocommerce' ); ?></a>
+			<a href="https://demo.wpswings.com/bookings-for-woocommerce-pro/" target="_blank" class="wps-overview-cta__btn"><?php esc_html_e( 'Demo', 'mwb-bookings-for-woocommerce' ); ?></a>
+			<a href="https://wpswings.com/woocommerce-plugins/" target="_blank" class="wps-overview-cta__btn"><?php esc_html_e( 'Support', 'mwb-bookings-for-woocommerce' ); ?></a>
+		</div>
+	</div>
+
 </div>

--- a/admin/partials/mwb-bookings-for-woocommerce-taxonomy-inline.php
+++ b/admin/partials/mwb-bookings-for-woocommerce-taxonomy-inline.php
@@ -1,0 +1,773 @@
+<?php
+/**
+ * Inline taxonomy management for Additional Costs and Additional Services.
+ *
+ * Renders the taxonomy Add New / Edit form and term listing table directly
+ * within the plugin admin panel (Configuration Settings tab) without
+ * redirecting to edit-tags.php or term.php.
+ *
+ * @link       https://wpswings.com/
+ * @since      3.11.6
+ *
+ * @package    Mwb_Bookings_For_Woocommerce
+ * @subpackage Mwb_Bookings_For_Woocommerce/admin/partials
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( ! isset( $taxonomy ) || ! taxonomy_exists( $taxonomy ) ) {
+	return;
+}
+
+if ( ! current_user_can( 'manage_woocommerce' ) ) {
+	wp_die( esc_html__( 'Permission denied.', 'mwb-bookings-for-woocommerce' ) );
+}
+
+$page_url    = admin_url( 'admin.php?page=mwb_bookings_for_woocommerce_menu&mbfw_tab=mwb-bookings-for-woocommerce-configuration&bfw_sub_nav=' . $taxonomy );
+$notice      = '';
+$notice_type = '';
+
+// --- Handle Add New Term ---
+if ( isset( $_POST['mwb_inline_tax_action'] ) && 'add-tag' === $_POST['mwb_inline_tax_action'] ) {
+	if ( ! isset( $_POST['_mwb_inline_nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['_mwb_inline_nonce'] ) ), 'mwb_inline_add_term_' . $taxonomy ) ) {
+		wp_die( esc_html__( 'Security check failed.', 'mwb-bookings-for-woocommerce' ) );
+	}
+
+	$term_name = isset( $_POST['tag-name'] ) ? sanitize_text_field( wp_unslash( $_POST['tag-name'] ) ) : '';
+	$term_slug = isset( $_POST['slug'] ) ? sanitize_title( wp_unslash( $_POST['slug'] ) ) : '';
+	$term_desc = isset( $_POST['description'] ) ? sanitize_textarea_field( wp_unslash( $_POST['description'] ) ) : '';
+
+	if ( empty( $term_name ) ) {
+		$notice      = __( 'Term name is required.', 'mwb-bookings-for-woocommerce' );
+		$notice_type = 'error';
+	} else {
+		$insert_args = array( 'description' => $term_desc );
+		if ( ! empty( $term_slug ) ) {
+			$insert_args['slug'] = $term_slug;
+		}
+		$result = wp_insert_term( $term_name, $taxonomy, $insert_args );
+
+		if ( ! is_wp_error( $result ) ) {
+			mwb_tax_inline_save_meta( $result['term_id'], $taxonomy );
+			wp_safe_redirect( add_query_arg( 'mwb_tax_notice', 'added', $page_url ) );
+			exit;
+		} else {
+			$notice      = $result->get_error_message();
+			$notice_type = 'error';
+		}
+	}
+}
+
+// --- Handle Update Term ---
+if ( isset( $_POST['mwb_inline_tax_action'] ) && 'edit-tag' === $_POST['mwb_inline_tax_action'] ) {
+	if ( ! isset( $_POST['_mwb_inline_nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['_mwb_inline_nonce'] ) ), 'mwb_inline_edit_term_' . $taxonomy ) ) {
+		wp_die( esc_html__( 'Security check failed.', 'mwb-bookings-for-woocommerce' ) );
+	}
+
+	$edit_id   = isset( $_POST['mwb_tax_term_id'] ) ? absint( $_POST['mwb_tax_term_id'] ) : 0;
+	$term_name = isset( $_POST['tag-name'] ) ? sanitize_text_field( wp_unslash( $_POST['tag-name'] ) ) : '';
+	$term_slug = isset( $_POST['slug'] ) ? sanitize_title( wp_unslash( $_POST['slug'] ) ) : '';
+	$term_desc = isset( $_POST['description'] ) ? sanitize_textarea_field( wp_unslash( $_POST['description'] ) ) : '';
+
+	if ( $edit_id && ! empty( $term_name ) ) {
+		$update_args = array( 'name' => $term_name, 'description' => $term_desc );
+		if ( ! empty( $term_slug ) ) {
+			$update_args['slug'] = $term_slug;
+		}
+		$result = wp_update_term( $edit_id, $taxonomy, $update_args );
+
+		if ( ! is_wp_error( $result ) ) {
+			mwb_tax_inline_save_meta( $edit_id, $taxonomy );
+			wp_safe_redirect( add_query_arg( 'mwb_tax_notice', 'updated', $page_url ) );
+			exit;
+		} else {
+			$notice      = $result->get_error_message();
+			$notice_type = 'error';
+		}
+	}
+}
+
+// --- Handle Delete from edit page ---
+if ( isset( $_GET['mwb_tax_delete'] ) && isset( $_GET['_wpnonce'] ) ) {
+	$del_id = absint( $_GET['mwb_tax_delete'] );
+	if ( wp_verify_nonce( sanitize_text_field( wp_unslash( $_GET['_wpnonce'] ) ), 'mwb_delete_term_' . $del_id ) ) {
+		wp_delete_term( $del_id, $taxonomy );
+		wp_safe_redirect( add_query_arg( 'mwb_tax_notice', 'deleted', $page_url ) );
+		exit;
+	}
+}
+
+// --- Handle Bulk Delete ---
+if ( isset( $_POST['mwb_bulk_action'] ) && 'delete' === $_POST['mwb_bulk_action'] && ! empty( $_POST['delete_tags'] ) ) {
+	if ( isset( $_POST['_mwb_bulk_nonce'] ) && wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['_mwb_bulk_nonce'] ) ), 'mwb_bulk_action_terms_' . $taxonomy ) ) {
+		foreach ( (array) $_POST['delete_tags'] as $bulk_term_id ) {
+			wp_delete_term( absint( $bulk_term_id ), $taxonomy );
+		}
+		wp_safe_redirect( add_query_arg( 'mwb_tax_notice', 'deleted', $page_url ) );
+		exit;
+	}
+}
+
+// --- Notices ---
+if ( isset( $_GET['mwb_tax_notice'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+	$notice_map = array(
+		'added'   => __( 'New item added successfully.', 'mwb-bookings-for-woocommerce' ),
+		'updated' => __( 'Item updated successfully.', 'mwb-bookings-for-woocommerce' ),
+		'deleted' => __( 'Item deleted successfully.', 'mwb-bookings-for-woocommerce' ),
+	);
+	$nkey = sanitize_key( $_GET['mwb_tax_notice'] ); // phpcs:ignore WordPress.Security.NonceVerification
+	if ( isset( $notice_map[ $nkey ] ) ) {
+		$notice      = $notice_map[ $nkey ];
+		$notice_type = 'updated';
+	}
+}
+
+// --- Edit mode ---
+$editing_term = null;
+$edit_id_get  = isset( $_GET['mwb_tax_edit'] ) ? absint( $_GET['mwb_tax_edit'] ) : 0; // phpcs:ignore WordPress.Security.NonceVerification
+if ( $edit_id_get ) {
+	$maybe = get_term( $edit_id_get, $taxonomy );
+	if ( $maybe && ! is_wp_error( $maybe ) ) {
+		$editing_term = $maybe;
+	}
+}
+
+// --- Search + terms (only for listing mode) ---
+$search = isset( $_GET['s'] ) ? sanitize_text_field( wp_unslash( $_GET['s'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification
+
+$query_args  = array( 'taxonomy' => $taxonomy, 'hide_empty' => false );
+if ( ! empty( $search ) ) {
+	$query_args['search'] = $search;
+}
+$terms       = get_terms( $query_args );
+$total_items = is_array( $terms ) ? count( $terms ) : 0;
+
+// --- Labels ---
+$tax_obj  = get_taxonomy( $taxonomy );
+$tax_sing = isset( $tax_obj->labels->singular_name ) ? $tax_obj->labels->singular_name : $tax_obj->label;
+
+if ( 'mwb_booking_cost' === $taxonomy ) {
+	$add_new_label = __( 'Add New Booking Cost', 'mwb-bookings-for-woocommerce' );
+	$search_label  = __( 'Search Booking Cost', 'mwb-bookings-for-woocommerce' );
+	$tax_desc      = __( 'This setting tab allows you to create different types of additional booking costs for your booking products i.e. the part of your booking product\'s additional resources or addons.', 'mwb-bookings-for-woocommerce' );
+} elseif ( 'mwb_booking_people' === $taxonomy ) {
+	$add_new_label = __( 'Add New People Type', 'mwb-bookings-for-woocommerce' );
+	$search_label  = __( 'Search People Type', 'mwb-bookings-for-woocommerce' );
+	$tax_desc      = __( 'You can create different types of people for your booking requests by using this setting tab. This is entirely optional; still, if your business requires type flexibility when bookings, then employ it.', 'bookings-for-woocommerce-pro' );
+} else {
+	$add_new_label = __( 'Add New Booking Service', 'mwb-bookings-for-woocommerce' );
+	$search_label  = __( 'Search Booking Service', 'mwb-bookings-for-woocommerce' );
+	$tax_desc      = __( 'This setting tab allows you to create different types of additional services for your booking products.', 'mwb-bookings-for-woocommerce' );
+}
+
+// --- Icons ---
+$icon_yes = '<span class="mwb-tax-icon mwb-tax-icon--yes">&#10003;</span>';
+$icon_no  = '<span class="mwb-tax-icon mwb-tax-icon--no">&#10005;</span>';
+
+/**
+ * Save custom term meta from POST.
+ *
+ * @param int    $term_id  Term ID.
+ * @param string $taxonomy Taxonomy slug.
+ */
+function mwb_tax_inline_save_meta( $term_id, $taxonomy ) {
+	if ( 'mwb_booking_cost' === $taxonomy ) {
+		update_term_meta( $term_id, 'mwb_mbfw_booking_cost', isset( $_POST['mwb_mbfw_booking_cost'] ) ? sanitize_text_field( wp_unslash( $_POST['mwb_mbfw_booking_cost'] ) ) : '' ); // phpcs:ignore WordPress.Security.NonceVerification
+		update_term_meta( $term_id, 'mwb_mbfw_is_booking_cost_multiply_people', isset( $_POST['mwb_mbfw_is_booking_cost_multiply_people'] ) ? 'yes' : '' ); // phpcs:ignore WordPress.Security.NonceVerification
+		update_term_meta( $term_id, 'mwb_mbfw_is_booking_cost_multiply_duration', isset( $_POST['mwb_mbfw_is_booking_cost_multiply_duration'] ) ? 'yes' : '' ); // phpcs:ignore WordPress.Security.NonceVerification
+	} elseif ( 'mwb_booking_service' === $taxonomy ) {
+		update_term_meta( $term_id, 'mwb_mbfw_service_cost', isset( $_POST['mwb_mbfw_service_cost'] ) ? sanitize_text_field( wp_unslash( $_POST['mwb_mbfw_service_cost'] ) ) : '' ); // phpcs:ignore WordPress.Security.NonceVerification
+		update_term_meta( $term_id, 'mwb_mbfw_is_service_cost_multiply_people', isset( $_POST['mwb_mbfw_is_service_cost_multiply_people'] ) ? 'yes' : '' ); // phpcs:ignore WordPress.Security.NonceVerification
+		update_term_meta( $term_id, 'mwb_mbfw_is_service_cost_multiply_duration', isset( $_POST['mwb_mbfw_is_service_cost_multiply_duration'] ) ? 'yes' : '' ); // phpcs:ignore WordPress.Security.NonceVerification
+		update_term_meta( $term_id, 'mwb_mbfw_is_service_optional', isset( $_POST['mwb_mbfw_is_service_optional'] ) ? 'yes' : '' ); // phpcs:ignore WordPress.Security.NonceVerification
+		update_term_meta( $term_id, 'mwb_mbfw_is_service_hidden', isset( $_POST['mwb_mbfw_is_service_hidden'] ) ? 'yes' : '' ); // phpcs:ignore WordPress.Security.NonceVerification
+		update_term_meta( $term_id, 'mwb_mbfw_is_service_has_quantity', isset( $_POST['mwb_mbfw_is_service_has_quantity'] ) ? 'yes' : '' ); // phpcs:ignore WordPress.Security.NonceVerification
+	} elseif ( 'mwb_booking_people' === $taxonomy ) {
+		update_term_meta( $term_id, 'mwb_bfwp_booking_people_unit_cost', isset( $_POST['mwb_bfwp_booking_people_unit_cost'] ) ? sanitize_text_field( wp_unslash( $_POST['mwb_bfwp_booking_people_unit_cost'] ) ) : '' ); // phpcs:ignore WordPress.Security.NonceVerification
+		update_term_meta( $term_id, 'mwb_bfwp_booking_people_base_cost', isset( $_POST['mwb_bfwp_booking_people_base_cost'] ) ? sanitize_text_field( wp_unslash( $_POST['mwb_bfwp_booking_people_base_cost'] ) ) : '' ); // phpcs:ignore WordPress.Security.NonceVerification
+		update_term_meta( $term_id, 'mwb_mbfw_minimum_people_per_booking', isset( $_POST['mwb_mbfw_minimum_people_per_booking'] ) ? sanitize_text_field( wp_unslash( $_POST['mwb_mbfw_minimum_people_per_booking'] ) ) : '' ); // phpcs:ignore WordPress.Security.NonceVerification
+		update_term_meta( $term_id, 'mwb_bfwp_booking_people_maximum_quantity', isset( $_POST['mwb_bfwp_booking_people_maximum_quantity'] ) ? sanitize_text_field( wp_unslash( $_POST['mwb_bfwp_booking_people_maximum_quantity'] ) ) : '' ); // phpcs:ignore WordPress.Security.NonceVerification
+	}
+}
+?>
+
+<div class="mwb-inline-taxonomy">
+
+	<?php if ( $notice ) : ?>
+		<div class="notice notice-<?php echo esc_attr( $notice_type ); ?> is-dismissible mwb-inline-tax-notice">
+			<p><?php echo esc_html( $notice ); ?></p>
+		</div>
+	<?php endif; ?>
+
+	<?php if ( $editing_term ) : ?>
+
+		<!-- ============================= -->
+		<!-- EDIT FORM (full-width)        -->
+		<!-- ============================= -->
+		<div class="mwb-inline-taxonomy__edit-wrap">
+
+			<div class="mwb-inline-taxonomy__edit-title-row">
+				<h2 class="mwb-inline-taxonomy__edit-title">
+					<?php
+					/* translators: %s: taxonomy singular name */
+					printf( esc_html__( 'Edit %s', 'mwb-bookings-for-woocommerce' ), esc_html( $tax_sing ) );
+					?>
+				</h2>
+				<a href="<?php echo esc_url( $page_url ); ?>" class="mwb-tax-back-link">
+					&larr; <?php esc_html_e( 'Back to list', 'mwb-bookings-for-woocommerce' ); ?>
+				</a>
+			</div>
+
+			<form method="post" action="<?php echo esc_url( $page_url ); ?>" class="mwb-inline-taxonomy__edit-form">
+				<?php wp_nonce_field( 'mwb_inline_edit_term_' . $taxonomy, '_mwb_inline_nonce' ); ?>
+				<input type="hidden" name="mwb_inline_tax_action" value="edit-tag" />
+				<input type="hidden" name="mwb_tax_term_id" value="<?php echo esc_attr( $editing_term->term_id ); ?>" />
+
+				<!-- Name -->
+				<div class="mwb-edit-field">
+					<label for="mwb-edit-name"><?php esc_html_e( 'Name', 'mwb-bookings-for-woocommerce' ); ?></label>
+					<div class="mwb-edit-field__control">
+						<input type="text" id="mwb-edit-name" name="tag-name" value="<?php echo esc_attr( $editing_term->name ); ?>" class="mwb-edit-field__text" />
+						<p class="description"><?php esc_html_e( 'The name is how it appears on your site.', 'mwb-bookings-for-woocommerce' ); ?></p>
+					</div>
+				</div>
+
+				<!-- Slug -->
+				<div class="mwb-edit-field">
+					<label for="mwb-edit-slug"><?php esc_html_e( 'Slug', 'mwb-bookings-for-woocommerce' ); ?></label>
+					<div class="mwb-edit-field__control">
+						<input type="text" id="mwb-edit-slug" name="slug" value="<?php echo esc_attr( $editing_term->slug ); ?>" class="mwb-edit-field__text" />
+						<p class="description"><?php esc_html_e( 'The &ldquo;slug&rdquo; is the URL-friendly version of the name. It is usually all lowercase and contains only letters, numbers, and hyphens.', 'mwb-bookings-for-woocommerce' ); ?></p>
+					</div>
+				</div>
+
+				<!-- Description -->
+				<div class="mwb-edit-field">
+					<label for="mwb-edit-desc"><?php esc_html_e( 'Description', 'mwb-bookings-for-woocommerce' ); ?></label>
+					<div class="mwb-edit-field__control">
+						<textarea id="mwb-edit-desc" name="description" rows="5" class="mwb-edit-field__textarea"><?php echo esc_textarea( $editing_term->description ); ?></textarea>
+						<p class="description"><?php esc_html_e( 'The description is not prominent by default; however, some themes may show it.', 'mwb-bookings-for-woocommerce' ); ?></p>
+					</div>
+				</div>
+
+				<?php if ( 'mwb_booking_cost' === $taxonomy ) : ?>
+
+					<!-- Booking Cost -->
+					<div class="mwb-edit-field">
+						<label for="mwb-edit-cost"><?php esc_html_e( 'Booking Cost', 'mwb-bookings-for-woocommerce' ); ?></label>
+						<div class="mwb-edit-field__control">
+							<input type="number" id="mwb-edit-cost" name="mwb_mbfw_booking_cost" min="0" step="0.01"
+								value="<?php echo esc_attr( get_term_meta( $editing_term->term_id, 'mwb_mbfw_booking_cost', true ) ); ?>"
+								style="width:10em;" />
+							<p class="description"><?php esc_html_e( 'Please Add booking cost here.', 'mwb-bookings-for-woocommerce' ); ?></p>
+						</div>
+					</div>
+
+					<!-- Multiply by No. of People -->
+					<div class="mwb-edit-field mwb-edit-field--toggle">
+						<label for="mwb-edit-people"><?php esc_html_e( 'Multiply by No. of People', 'mwb-bookings-for-woocommerce' ); ?></label>
+						<div class="mwb-edit-field__control">
+							<input type="checkbox" class="mwb-tax-toggle" id="mwb-edit-people"
+								name="mwb_mbfw_is_booking_cost_multiply_people" value="yes"
+								<?php checked( get_term_meta( $editing_term->term_id, 'mwb_mbfw_is_booking_cost_multiply_people', true ), 'yes' ); ?> />
+							<p class="description"><?php esc_html_e( 'Either to multiply by number of people.', 'mwb-bookings-for-woocommerce' ); ?></p>
+						</div>
+					</div>
+
+					<!-- Multiply by Duration of Booking -->
+					<div class="mwb-edit-field mwb-edit-field--toggle">
+						<label for="mwb-edit-duration"><?php esc_html_e( 'Multiply by Duration of Booking', 'mwb-bookings-for-woocommerce' ); ?></label>
+						<div class="mwb-edit-field__control">
+							<input type="checkbox" class="mwb-tax-toggle" id="mwb-edit-duration"
+								name="mwb_mbfw_is_booking_cost_multiply_duration" value="yes"
+								<?php checked( get_term_meta( $editing_term->term_id, 'mwb_mbfw_is_booking_cost_multiply_duration', true ), 'yes' ); ?> />
+							<p class="description"><?php esc_html_e( 'Either to multiply by Duration of Booking.', 'mwb-bookings-for-woocommerce' ); ?></p>
+						</div>
+					</div>
+
+				<?php elseif ( 'mwb_booking_service' === $taxonomy ) : ?>
+
+					<!-- Service Cost -->
+					<div class="mwb-edit-field">
+						<label for="mwb-edit-cost"><?php esc_html_e( 'Service Cost', 'mwb-bookings-for-woocommerce' ); ?></label>
+						<div class="mwb-edit-field__control">
+							<input type="number" id="mwb-edit-cost" name="mwb_mbfw_service_cost" min="0" step="0.01"
+								value="<?php echo esc_attr( get_term_meta( $editing_term->term_id, 'mwb_mbfw_service_cost', true ) ); ?>"
+								style="width:10em;" />
+							<p class="description"><?php esc_html_e( 'Please Add service cost here.', 'mwb-bookings-for-woocommerce' ); ?></p>
+						</div>
+					</div>
+
+					<!-- Multiply by Number of People -->
+					<div class="mwb-edit-field mwb-edit-field--toggle">
+						<label for="mwb-edit-people"><?php esc_html_e( 'Multiply by Number of People', 'mwb-bookings-for-woocommerce' ); ?></label>
+						<div class="mwb-edit-field__control">
+							<input type="checkbox" class="mwb-tax-toggle" id="mwb-edit-people"
+								name="mwb_mbfw_is_service_cost_multiply_people" value="yes"
+								<?php checked( get_term_meta( $editing_term->term_id, 'mwb_mbfw_is_service_cost_multiply_people', true ), 'yes' ); ?> />
+							<p class="description"><?php esc_html_e( 'Either to multiply by number of people.', 'mwb-bookings-for-woocommerce' ); ?></p>
+						</div>
+					</div>
+
+					<!-- Multiply by Booking Duration -->
+					<div class="mwb-edit-field mwb-edit-field--toggle">
+						<label for="mwb-edit-duration"><?php esc_html_e( 'Multiply by Booking Duration', 'mwb-bookings-for-woocommerce' ); ?></label>
+						<div class="mwb-edit-field__control">
+							<input type="checkbox" class="mwb-tax-toggle" id="mwb-edit-duration"
+								name="mwb_mbfw_is_service_cost_multiply_duration" value="yes"
+								<?php checked( get_term_meta( $editing_term->term_id, 'mwb_mbfw_is_service_cost_multiply_duration', true ), 'yes' ); ?> />
+							<p class="description"><?php esc_html_e( 'Either to multiply by Booking Duration.', 'mwb-bookings-for-woocommerce' ); ?></p>
+						</div>
+					</div>
+
+					<!-- If Optional -->
+					<div class="mwb-edit-field mwb-edit-field--toggle">
+						<label for="mwb-edit-optional"><?php esc_html_e( 'If Optional', 'mwb-bookings-for-woocommerce' ); ?></label>
+						<div class="mwb-edit-field__control">
+							<input type="checkbox" class="mwb-tax-toggle" id="mwb-edit-optional"
+								name="mwb_mbfw_is_service_optional" value="yes"
+								<?php checked( get_term_meta( $editing_term->term_id, 'mwb_mbfw_is_service_optional', true ), 'yes' ); ?> />
+							<p class="description"><?php esc_html_e( 'Either the Service is Optional.', 'mwb-bookings-for-woocommerce' ); ?></p>
+						</div>
+					</div>
+
+					<!-- If Hidden -->
+					<div class="mwb-edit-field mwb-edit-field--toggle">
+						<label for="mwb-edit-hidden"><?php esc_html_e( 'If Hidden', 'mwb-bookings-for-woocommerce' ); ?></label>
+						<div class="mwb-edit-field__control">
+							<input type="checkbox" class="mwb-tax-toggle" id="mwb-edit-hidden"
+								name="mwb_mbfw_is_service_hidden" value="yes"
+								<?php checked( get_term_meta( $editing_term->term_id, 'mwb_mbfw_is_service_hidden', true ), 'yes' ); ?> />
+							<p class="description"><?php esc_html_e( 'Either the Service is Hidden.', 'mwb-bookings-for-woocommerce' ); ?></p>
+						</div>
+					</div>
+
+					<!-- If Has Quantity -->
+					<div class="mwb-edit-field mwb-edit-field--toggle">
+						<label for="mwb-edit-qty"><?php esc_html_e( 'If has Quantity', 'mwb-bookings-for-woocommerce' ); ?></label>
+						<div class="mwb-edit-field__control">
+							<input type="checkbox" class="mwb-tax-toggle" id="mwb-edit-qty"
+								name="mwb_mbfw_is_service_has_quantity" value="yes"
+								<?php checked( get_term_meta( $editing_term->term_id, 'mwb_mbfw_is_service_has_quantity', true ), 'yes' ); ?> />
+							<p class="description"><?php esc_html_e( 'Either the service has quantity.', 'mwb-bookings-for-woocommerce' ); ?></p>
+						</div>
+					</div>
+
+
+				<?php elseif ( 'mwb_booking_people' === $taxonomy ) : ?>
+
+					<div class="mwb-edit-field">
+						<label for="mwb-edit-unit-cost"><?php esc_html_e( 'Unit Cost', 'bookings-for-woocommerce-pro' ); ?></label>
+						<div class="mwb-edit-field__control">
+							<input type="number" id="mwb-edit-unit-cost" name="mwb_bfwp_booking_people_unit_cost" min="0" step="0.01"
+								value="<?php echo esc_attr( get_term_meta( $editing_term->term_id, 'mwb_bfwp_booking_people_unit_cost', true ) ); ?>"
+								style="width:10em;" />
+							<p class="description"><?php esc_html_e( 'Enter unit cost i.e. the booking unit cost for the people type that you’re creating to book for.', 'bookings-for-woocommerce-pro' ); ?></p>
+						</div>
+					</div>
+
+					<div class="mwb-edit-field">
+						<label for="mwb-edit-base-cost"><?php esc_html_e( 'Base Cost', 'bookings-for-woocommerce-pro' ); ?></label>
+						<div class="mwb-edit-field__control">
+							<input type="number" id="mwb-edit-base-cost" name="mwb_bfwp_booking_people_base_cost" min="0" step="0.01"
+								value="<?php echo esc_attr( get_term_meta( $editing_term->term_id, 'mwb_bfwp_booking_people_base_cost', true ) ); ?>"
+								style="width:10em;" />
+							<p class="description"><?php esc_html_e( 'Enter base cost i.e. the base rental cost for the people type that you’re creating to book for.', 'bookings-for-woocommerce-pro' ); ?></p>
+						</div>
+					</div>
+
+					<div class="mwb-edit-field">
+						<label for="mwb-edit-min-qty"><?php esc_html_e( 'Minimum Quantity', 'bookings-for-woocommerce-pro' ); ?></label>
+						<div class="mwb-edit-field__control">
+							<input type="number" id="mwb-edit-min-qty" name="mwb_mbfw_minimum_people_per_booking"
+								value="<?php echo esc_attr( get_term_meta( $editing_term->term_id, 'mwb_mbfw_minimum_people_per_booking', true ) ); ?>"
+								style="width:10em;" />
+							<p class="description"><?php esc_html_e( 'Minimum Quantity of peoples allowed for respective people type that you’re creating.', 'bookings-for-woocommerce-pro' ); ?></p>
+						</div>
+					</div>
+
+					<div class="mwb-edit-field">
+						<label for="mwb-edit-max-qty"><?php esc_html_e( 'Maximum Quantity', 'bookings-for-woocommerce-pro' ); ?></label>
+						<div class="mwb-edit-field__control">
+							<input type="number" id="mwb-edit-max-qty" name="mwb_bfwp_booking_people_maximum_quantity"
+								value="<?php echo esc_attr( get_term_meta( $editing_term->term_id, 'mwb_bfwp_booking_people_maximum_quantity', true ) ); ?>"
+								style="width:10em;" />
+							<p class="description"><?php esc_html_e( 'Maximum Quantity of peoples allowed for respective people type that you’re creating.', 'bookings-for-woocommerce-pro' ); ?></p>
+						</div>
+					</div>
+				<?php endif; ?>
+
+				<!-- Actions -->
+				<div class="mwb-edit-field mwb-edit-field--actions">
+					<label></label>
+					<div class="mwb-edit-field__control mwb-edit-actions">
+						<button type="submit" class="mwb-btn mwb-btn--primary"><?php esc_html_e( 'Update', 'mwb-bookings-for-woocommerce' ); ?></button>
+						<a href="<?php echo esc_url( add_query_arg( array( 'mwb_tax_delete' => $editing_term->term_id, '_wpnonce' => wp_create_nonce( 'mwb_delete_term_' . $editing_term->term_id ) ), $page_url ) ); ?>"
+							class="mwb-edit-delete-link"
+							onclick="return confirm('<?php esc_attr_e( 'Are you sure you want to delete this item?', 'mwb-bookings-for-woocommerce' ); ?>')">
+							<?php esc_html_e( 'Delete', 'mwb-bookings-for-woocommerce' ); ?>
+						</a>
+					</div>
+				</div>
+
+			</form>
+		</div><!-- /.mwb-inline-taxonomy__edit-wrap -->
+
+	<?php else : ?>
+
+		<!-- ============================= -->
+		<!-- ADD NEW + LISTING (two-col)   -->
+		<!-- ============================= -->
+		<div class="mwb-inline-taxonomy__layout">
+
+			<!-- LEFT: Add New Form -->
+			<div class="mwb-inline-taxonomy__add-col">
+				<p class="mwb-inline-taxonomy__desc"><?php echo esc_html( $tax_desc ); ?></p>
+
+				<h3 class="mwb-inline-taxonomy__form-title"><?php echo esc_html( $add_new_label ); ?></h3>
+
+				<form method="post" action="<?php echo esc_url( $page_url ); ?>" class="mwb-inline-taxonomy__form">
+					<?php wp_nonce_field( 'mwb_inline_add_term_' . $taxonomy, '_mwb_inline_nonce' ); ?>
+					<input type="hidden" name="mwb_inline_tax_action" value="add-tag" />
+
+					<div class="mwb-tax-field">
+						<label for="mwb-tax-name"><?php esc_html_e( 'Name', 'mwb-bookings-for-woocommerce' ); ?></label>
+						<div class="mwb-tax-field__input">
+							<input type="text" id="mwb-tax-name" name="tag-name" value="" />
+							<p class="description"><?php esc_html_e( 'The name is how it appears on your site.', 'mwb-bookings-for-woocommerce' ); ?></p>
+						</div>
+					</div>
+
+					<div class="mwb-tax-field">
+						<label for="mwb-tax-slug"><?php esc_html_e( 'Slug', 'mwb-bookings-for-woocommerce' ); ?></label>
+						<div class="mwb-tax-field__input">
+							<input type="text" id="mwb-tax-slug" name="slug" value="" />
+							<p class="description"><?php esc_html_e( 'The &ldquo;slug&rdquo; is the URL-friendly version of the name. It is usually all lowercase and contains only letters, numbers, and hyphens.', 'mwb-bookings-for-woocommerce' ); ?></p>
+						</div>
+					</div>
+
+					<div class="mwb-tax-field">
+						<label for="mwb-tax-desc"><?php esc_html_e( 'Description', 'mwb-bookings-for-woocommerce' ); ?></label>
+						<div class="mwb-tax-field__input">
+							<textarea id="mwb-tax-desc" name="description" rows="5"></textarea>
+							<p class="description"><?php esc_html_e( 'The description is not prominent by default; however, some themes may show it.', 'mwb-bookings-for-woocommerce' ); ?></p>
+						</div>
+					</div>
+
+					<?php if ( 'mwb_booking_cost' === $taxonomy ) : ?>
+
+						<div class="mwb-tax-field">
+							<label for="mwb_mbfw_booking_cost"><?php esc_html_e( 'Booking Cost', 'mwb-bookings-for-woocommerce' ); ?></label>
+							<div class="mwb-tax-field__input">
+								<input type="number" id="mwb_mbfw_booking_cost" name="mwb_mbfw_booking_cost" min="0" step="0.01" style="width:10em;" />
+								<p class="description"><?php esc_html_e( 'Please Add Booking cost here.', 'mwb-bookings-for-woocommerce' ); ?></p>
+							</div>
+						</div>
+
+						<div class="mwb-tax-field mwb-tax-field--toggle">
+							<label for="mwb_mbfw_is_booking_cost_multiply_people"><?php esc_html_e( 'Multiply by No. of People', 'mwb-bookings-for-woocommerce' ); ?></label>
+							<div class="mwb-tax-field__input">
+								<input type="checkbox" class="mwb-tax-toggle" id="mwb_mbfw_is_booking_cost_multiply_people" name="mwb_mbfw_is_booking_cost_multiply_people" value="yes" />
+								<p class="description"><?php esc_html_e( 'Either to multiply by number of people.', 'mwb-bookings-for-woocommerce' ); ?></p>
+							</div>
+						</div>
+
+						<div class="mwb-tax-field mwb-tax-field--toggle">
+							<label for="mwb_mbfw_is_booking_cost_multiply_duration"><?php esc_html_e( 'Multiply by Duration', 'mwb-bookings-for-woocommerce' ); ?></label>
+							<div class="mwb-tax-field__input">
+								<input type="checkbox" class="mwb-tax-toggle" id="mwb_mbfw_is_booking_cost_multiply_duration" name="mwb_mbfw_is_booking_cost_multiply_duration" value="yes" />
+								<p class="description"><?php esc_html_e( 'Either to multiply by Duration of Booking.', 'mwb-bookings-for-woocommerce' ); ?></p>
+							</div>
+						</div>
+
+					<?php elseif ( 'mwb_booking_service' === $taxonomy ) : ?>
+
+						<div class="mwb-tax-field">
+							<label for="mwb_mbfw_service_cost"><?php esc_html_e( 'Service Cost', 'mwb-bookings-for-woocommerce' ); ?></label>
+							<div class="mwb-tax-field__input">
+								<input type="number" id="mwb_mbfw_service_cost" name="mwb_mbfw_service_cost" min="0" step="0.01" style="width:10em;" />
+								<p class="description"><?php esc_html_e( 'Please Add service cost here.', 'mwb-bookings-for-woocommerce' ); ?></p>
+							</div>
+						</div>
+
+						<div class="mwb-tax-field mwb-tax-field--toggle">
+							<label for="mwb_mbfw_is_service_cost_multiply_people"><?php esc_html_e( 'Multiply by Number of People', 'mwb-bookings-for-woocommerce' ); ?></label>
+							<div class="mwb-tax-field__input">
+								<input type="checkbox" class="mwb-tax-toggle" id="mwb_mbfw_is_service_cost_multiply_people" name="mwb_mbfw_is_service_cost_multiply_people" value="yes" />
+								<p class="description"><?php esc_html_e( 'Either to multiply by number of people.', 'mwb-bookings-for-woocommerce' ); ?></p>
+							</div>
+						</div>
+
+						<div class="mwb-tax-field mwb-tax-field--toggle">
+							<label for="mwb_mbfw_is_service_cost_multiply_duration"><?php esc_html_e( 'Multiply by Booking Duration', 'mwb-bookings-for-woocommerce' ); ?></label>
+							<div class="mwb-tax-field__input">
+								<input type="checkbox" class="mwb-tax-toggle" id="mwb_mbfw_is_service_cost_multiply_duration" name="mwb_mbfw_is_service_cost_multiply_duration" value="yes" />
+								<p class="description"><?php esc_html_e( 'Either to multiply by Booking Duration.', 'mwb-bookings-for-woocommerce' ); ?></p>
+							</div>
+						</div>
+
+						<div class="mwb-tax-field mwb-tax-field--toggle">
+							<label for="mwb_mbfw_is_service_optional"><?php esc_html_e( 'If Optional', 'mwb-bookings-for-woocommerce' ); ?></label>
+							<div class="mwb-tax-field__input">
+								<input type="checkbox" class="mwb-tax-toggle" id="mwb_mbfw_is_service_optional" name="mwb_mbfw_is_service_optional" value="yes" />
+								<p class="description"><?php esc_html_e( 'Either the Service is Optional.', 'mwb-bookings-for-woocommerce' ); ?></p>
+							</div>
+						</div>
+
+						<div class="mwb-tax-field mwb-tax-field--toggle">
+							<label for="mwb_mbfw_is_service_hidden"><?php esc_html_e( 'If Hidden', 'mwb-bookings-for-woocommerce' ); ?></label>
+							<div class="mwb-tax-field__input">
+								<input type="checkbox" class="mwb-tax-toggle" id="mwb_mbfw_is_service_hidden" name="mwb_mbfw_is_service_hidden" value="yes" />
+								<p class="description"><?php esc_html_e( 'Either the Service is Hidden.', 'mwb-bookings-for-woocommerce' ); ?></p>
+							</div>
+						</div>
+
+						<div class="mwb-tax-field mwb-tax-field--toggle">
+							<label for="mwb_mbfw_is_service_has_quantity"><?php esc_html_e( 'If has Quantity', 'mwb-bookings-for-woocommerce' ); ?></label>
+							<div class="mwb-tax-field__input">
+								<input type="checkbox" class="mwb-tax-toggle" id="mwb_mbfw_is_service_has_quantity" name="mwb_mbfw_is_service_has_quantity" value="yes" />
+								<p class="description"><?php esc_html_e( 'Either the service has quantity.', 'mwb-bookings-for-woocommerce' ); ?></p>
+							</div>
+						</div>
+
+
+					<?php elseif ( 'mwb_booking_people' === $taxonomy ) : ?>
+
+						<div class="mwb-tax-field">
+							<label for="mwb_bfwp_booking_people_unit_cost"><?php esc_html_e( 'Unit Cost', 'bookings-for-woocommerce-pro' ); ?></label>
+							<div class="mwb-tax-field__input">
+								<input type="number" id="mwb_bfwp_booking_people_unit_cost" name="mwb_bfwp_booking_people_unit_cost" min="0" step="0.01" style="width:10em;" />
+								<p class="description"><?php esc_html_e( 'Enter unit cost i.e. the booking unit cost for the people type that you’re creating to book for.', 'bookings-for-woocommerce-pro' ); ?></p>
+							</div>
+						</div>
+
+						<div class="mwb-tax-field">
+							<label for="mwb_bfwp_booking_people_base_cost"><?php esc_html_e( 'Base Cost', 'bookings-for-woocommerce-pro' ); ?></label>
+							<div class="mwb-tax-field__input">
+								<input type="number" id="mwb_bfwp_booking_people_base_cost" name="mwb_bfwp_booking_people_base_cost" min="0" step="0.01" style="width:10em;" />
+								<p class="description"><?php esc_html_e( 'Enter base cost i.e. the base rental cost for the people type that you’re creating to book for.', 'bookings-for-woocommerce-pro' ); ?></p>
+							</div>
+						</div>
+
+						<div class="mwb-tax-field">
+							<label for="mwb_mbfw_minimum_people_per_booking"><?php esc_html_e( 'Minimum Quantity', 'bookings-for-woocommerce-pro' ); ?></label>
+							<div class="mwb-tax-field__input">
+								<input type="number" id="mwb_mbfw_minimum_people_per_booking" name="mwb_mbfw_minimum_people_per_booking" style="width:10em;" />
+								<p class="description"><?php esc_html_e( 'Minimum Quantity of peoples allowed for respective people type that you’re creating.', 'bookings-for-woocommerce-pro' ); ?></p>
+							</div>
+						</div>
+
+						<div class="mwb-tax-field">
+							<label for="mwb_bfwp_booking_people_maximum_quantity"><?php esc_html_e( 'Maximum Quantity', 'bookings-for-woocommerce-pro' ); ?></label>
+							<div class="mwb-tax-field__input">
+								<input type="number" id="mwb_bfwp_booking_people_maximum_quantity" name="mwb_bfwp_booking_people_maximum_quantity" style="width:10em;" />
+								<p class="description"><?php esc_html_e( 'Maximum Quantity of peoples allowed for respective people type that you’re creating.', 'bookings-for-woocommerce-pro' ); ?></p>
+							</div>
+						</div>
+					<?php endif; ?>
+
+					<div class="mwb-tax-field mwb-tax-field--submit">
+						<label></label>
+						<div class="mwb-tax-field__input">
+							<button type="submit" class="mwb-btn mwb-btn--primary"><?php echo esc_html( $add_new_label ); ?></button>
+						</div>
+					</div>
+
+				</form>
+			</div><!-- /.mwb-inline-taxonomy__add-col -->
+
+			<!-- RIGHT: Terms Listing Table -->
+			<div class="mwb-inline-taxonomy__table-col">
+
+				<!-- Search -->
+				<form method="get" action="<?php echo esc_url( admin_url( 'admin.php' ) ); ?>" class="mwb-inline-taxonomy__search-form">
+					<input type="hidden" name="page" value="mwb_bookings_for_woocommerce_menu" />
+					<input type="hidden" name="mbfw_tab" value="mwb-bookings-for-woocommerce-configuration" />
+					<input type="hidden" name="bfw_sub_nav" value="<?php echo esc_attr( $taxonomy ); ?>" />
+					<input type="text" name="s" value="<?php echo esc_attr( $search ); ?>" class="mwb-inline-taxonomy__search-input" />
+					<button type="submit" class="button"><?php echo esc_html( $search_label ); ?></button>
+				</form>
+
+				<!-- Bulk Action Form -->
+				<form method="post" action="<?php echo esc_url( $page_url ); ?>" class="mwb-inline-taxonomy__bulk-form">
+					<?php wp_nonce_field( 'mwb_bulk_action_terms_' . $taxonomy, '_mwb_bulk_nonce' ); ?>
+
+					<div class="mwb-inline-taxonomy__bulk-bar">
+						<select name="mwb_bulk_action">
+							<option value="-1"><?php esc_html_e( 'Bulk actions', 'mwb-bookings-for-woocommerce' ); ?></option>
+							<option value="delete"><?php esc_html_e( 'Delete', 'mwb-bookings-for-woocommerce' ); ?></option>
+						</select>
+						<button type="submit" class="button mwb-inline-taxonomy__apply-btn"><?php esc_html_e( 'Apply', 'mwb-bookings-for-woocommerce' ); ?></button>
+						<span class="mwb-inline-taxonomy__count">
+							<?php echo esc_html( sprintf( _n( '%d item', '%d items', $total_items, 'mwb-bookings-for-woocommerce' ), $total_items ) ); ?>
+						</span>
+					</div>
+
+					<table class="mwb-inline-taxonomy__table widefat">
+						<thead>
+							<tr>
+								<td class="check-column"><input type="checkbox" id="mwb-tax-select-all" /></td>
+								<th><?php esc_html_e( 'Name', 'mwb-bookings-for-woocommerce' ); ?></th>
+								<?php if ( 'mwb_booking_cost' === $taxonomy ) : ?>
+									<th><?php esc_html_e( 'Cost', 'mwb-bookings-for-woocommerce' ); ?></th>
+									<th><?php esc_html_e( 'People', 'mwb-bookings-for-woocommerce' ); ?></th>
+									<th><?php esc_html_e( 'Duration', 'mwb-bookings-for-woocommerce' ); ?></th>
+								<?php elseif ( 'mwb_booking_people' === $taxonomy ) : ?>
+									<th><?php esc_html_e( 'Unit Cost', 'bookings-for-woocommerce-pro' ); ?></th>
+									<th><?php esc_html_e( 'Base Cost', 'bookings-for-woocommerce-pro' ); ?></th>
+									<th><?php esc_html_e( 'Minimum Quantity', 'bookings-for-woocommerce-pro' ); ?></th>
+									<th><?php esc_html_e( 'Maximum Quantity', 'bookings-for-woocommerce-pro' ); ?></th>
+								<?php else : ?>
+									<th><?php esc_html_e( 'Cost', 'mwb-bookings-for-woocommerce' ); ?></th>
+									<th><?php esc_html_e( 'People', 'mwb-bookings-for-woocommerce' ); ?></th>
+									<th><?php esc_html_e( 'Duration', 'mwb-bookings-for-woocommerce' ); ?></th>
+									<th><?php esc_html_e( 'Optional', 'mwb-bookings-for-woocommerce' ); ?></th>
+									<th><?php esc_html_e( 'Hidden', 'mwb-bookings-for-woocommerce' ); ?></th>
+									<th><?php esc_html_e( 'Quantity', 'mwb-bookings-for-woocommerce' ); ?></th>
+								<?php endif; ?>
+							</tr>
+						</thead>
+						<tbody>
+							<?php if ( ! empty( $terms ) && ! is_wp_error( $terms ) ) : ?>
+								<?php foreach ( $terms as $term ) : ?>
+									<?php
+									$row_edit_url = add_query_arg( 'mwb_tax_edit', $term->term_id, $page_url );
+									$row_del_url  = add_query_arg(
+										array(
+											'mwb_tax_delete' => $term->term_id,
+											'_wpnonce'       => wp_create_nonce( 'mwb_delete_term_' . $term->term_id ),
+										),
+										$page_url
+									);
+									?>
+									<tr class="mwb-inline-taxonomy__row">
+										<th class="check-column">
+											<input type="checkbox" name="delete_tags[]" value="<?php echo esc_attr( $term->term_id ); ?>" />
+										</th>
+										<td class="column-name">
+											<strong><a href="<?php echo esc_url( $row_edit_url ); ?>"><?php echo esc_html( $term->name ); ?></a></strong>
+											<div class="row-actions">
+												<span class="edit"><a href="<?php echo esc_url( $row_edit_url ); ?>"><?php esc_html_e( 'Edit', 'mwb-bookings-for-woocommerce' ); ?></a> | </span>
+												<span class="delete">
+													<a href="<?php echo esc_url( $row_del_url ); ?>" class="mwb-tax-delete-link"
+														onclick="return confirm('<?php esc_attr_e( 'Are you sure you want to delete this item?', 'mwb-bookings-for-woocommerce' ); ?>')">
+														<?php esc_html_e( 'Delete', 'mwb-bookings-for-woocommerce' ); ?>
+													</a>
+												</span>
+											</div>
+										</td>
+										<?php if ( 'mwb_booking_cost' === $taxonomy ) : ?>
+											<td><?php echo esc_html( get_term_meta( $term->term_id, 'mwb_mbfw_booking_cost', true ) ); ?></td>
+											<td><?php echo ( 'yes' === get_term_meta( $term->term_id, 'mwb_mbfw_is_booking_cost_multiply_people', true ) ) ? wp_kses_post( $icon_yes ) : wp_kses_post( $icon_no ); ?></td>
+											<td><?php echo ( 'yes' === get_term_meta( $term->term_id, 'mwb_mbfw_is_booking_cost_multiply_duration', true ) ) ? wp_kses_post( $icon_yes ) : wp_kses_post( $icon_no ); ?></td>
+										<?php elseif ( 'mwb_booking_people' === $taxonomy ) : ?>
+											<td><?php echo esc_html( get_term_meta( $term->term_id, 'mwb_bfwp_booking_people_unit_cost', true ) ); ?></td>
+											<td><?php echo esc_html( get_term_meta( $term->term_id, 'mwb_bfwp_booking_people_base_cost', true ) ); ?></td>
+											<td><?php echo esc_html( get_term_meta( $term->term_id, 'mwb_mbfw_minimum_people_per_booking', true ) ); ?></td>
+											<td><?php echo esc_html( get_term_meta( $term->term_id, 'mwb_bfwp_booking_people_maximum_quantity', true ) ); ?></td>
+										<?php else : ?>
+											<td><?php echo esc_html( get_term_meta( $term->term_id, 'mwb_mbfw_service_cost', true ) ); ?></td>
+											<td><?php echo ( 'yes' === get_term_meta( $term->term_id, 'mwb_mbfw_is_service_cost_multiply_people', true ) ) ? wp_kses_post( $icon_yes ) : wp_kses_post( $icon_no ); ?></td>
+											<td><?php echo ( 'yes' === get_term_meta( $term->term_id, 'mwb_mbfw_is_service_cost_multiply_duration', true ) ) ? wp_kses_post( $icon_yes ) : wp_kses_post( $icon_no ); ?></td>
+											<td><?php echo ( 'yes' === get_term_meta( $term->term_id, 'mwb_mbfw_is_service_optional', true ) ) ? wp_kses_post( $icon_yes ) : wp_kses_post( $icon_no ); ?></td>
+											<td><?php echo ( 'yes' === get_term_meta( $term->term_id, 'mwb_mbfw_is_service_hidden', true ) ) ? wp_kses_post( $icon_yes ) : wp_kses_post( $icon_no ); ?></td>
+											<td><?php echo ( 'yes' === get_term_meta( $term->term_id, 'mwb_mbfw_is_service_has_quantity', true ) ) ? wp_kses_post( $icon_yes ) : wp_kses_post( $icon_no ); ?></td>
+										<?php endif; ?>
+									</tr>
+								<?php endforeach; ?>
+							<?php else : ?>
+								<tr>
+									<td colspan="<?php echo 'mwb_booking_cost' === $taxonomy ? 5 : ( 'mwb_booking_people' === $taxonomy ? 6 : 8 ); ?>" class="mwb-inline-taxonomy__no-items">
+										<?php esc_html_e( 'No items found.', 'mwb-bookings-for-woocommerce' ); ?>
+									</td>
+								</tr>
+							<?php endif; ?>
+						</tbody>
+						<tfoot>
+							<tr>
+								<td class="check-column"><input type="checkbox" /></td>
+								<th><?php esc_html_e( 'Name', 'mwb-bookings-for-woocommerce' ); ?></th>
+								<?php if ( 'mwb_booking_cost' === $taxonomy ) : ?>
+									<th><?php esc_html_e( 'Cost', 'mwb-bookings-for-woocommerce' ); ?></th>
+									<th><?php esc_html_e( 'People', 'mwb-bookings-for-woocommerce' ); ?></th>
+									<th><?php esc_html_e( 'Duration', 'mwb-bookings-for-woocommerce' ); ?></th>
+								<?php elseif ( 'mwb_booking_people' === $taxonomy ) : ?>
+									<th><?php esc_html_e( 'Unit Cost', 'bookings-for-woocommerce-pro' ); ?></th>
+									<th><?php esc_html_e( 'Base Cost', 'bookings-for-woocommerce-pro' ); ?></th>
+									<th><?php esc_html_e( 'Minimum Quantity', 'bookings-for-woocommerce-pro' ); ?></th>
+									<th><?php esc_html_e( 'Maximum Quantity', 'bookings-for-woocommerce-pro' ); ?></th>
+								<?php else : ?>
+									<th><?php esc_html_e( 'Cost', 'mwb-bookings-for-woocommerce' ); ?></th>
+									<th><?php esc_html_e( 'People', 'mwb-bookings-for-woocommerce' ); ?></th>
+									<th><?php esc_html_e( 'Duration', 'mwb-bookings-for-woocommerce' ); ?></th>
+									<th><?php esc_html_e( 'Optional', 'mwb-bookings-for-woocommerce' ); ?></th>
+									<th><?php esc_html_e( 'Hidden', 'mwb-bookings-for-woocommerce' ); ?></th>
+									<th><?php esc_html_e( 'Quantity', 'mwb-bookings-for-woocommerce' ); ?></th>
+								<?php endif; ?>
+							</tr>
+						</tfoot>
+					</table>
+
+					<div class="mwb-inline-taxonomy__bulk-bar mwb-inline-taxonomy__bulk-bar--bottom">
+						<select name="mwb_bulk_action">
+							<option value="-1"><?php esc_html_e( 'Bulk actions', 'mwb-bookings-for-woocommerce' ); ?></option>
+							<option value="delete"><?php esc_html_e( 'Delete', 'mwb-bookings-for-woocommerce' ); ?></option>
+						</select>
+						<button type="submit" class="button mwb-inline-taxonomy__apply-btn"><?php esc_html_e( 'Apply', 'mwb-bookings-for-woocommerce' ); ?></button>
+						<span class="mwb-inline-taxonomy__count">
+							<?php echo esc_html( sprintf( _n( '%d item', '%d items', $total_items, 'mwb-bookings-for-woocommerce' ), $total_items ) ); ?>
+						</span>
+					</div>
+
+				</form>
+			</div><!-- /.mwb-inline-taxonomy__table-col -->
+
+		</div><!-- /.mwb-inline-taxonomy__layout -->
+
+	<?php endif; ?>
+
+</div><!-- /.mwb-inline-taxonomy -->
+
+<script>
+( function() {
+	// Wrap every .mwb-tax-toggle checkbox in a label+span for the custom switch UI.
+	// The real checkbox is hidden; the <span> track is styled via CSS.
+	document.querySelectorAll( '.mwb-tax-toggle' ).forEach( function( checkbox ) {
+		var wrapper = document.createElement( 'label' );
+		wrapper.className = 'mwb-tax-switch';
+
+		var track = document.createElement( 'span' );
+		track.className = 'mwb-tax-switch__track';
+
+		checkbox.parentNode.insertBefore( wrapper, checkbox );
+		wrapper.appendChild( checkbox );
+		wrapper.appendChild( track );
+	} );
+
+	// Wrap bulk-action table checkboxes with .wps-checkbox structure (orange box + blue halo).
+	document.querySelectorAll( '.mwb-inline-taxonomy__table .check-column input[type="checkbox"]' ).forEach( function( checkbox ) {
+		var wrapper = document.createElement( 'label' );
+		wrapper.className = 'wps-checkbox mwb-tax-table-cb';
+
+		var box = document.createElement( 'span' );
+		box.className = 'wps-checkbox__box';
+
+		checkbox.classList.add( 'wps-checkbox__input' );
+		checkbox.parentNode.insertBefore( wrapper, checkbox );
+		wrapper.appendChild( checkbox );
+		wrapper.appendChild( box );
+	} );
+
+	// Select-all checkbox for bulk actions.
+	var selectAll = document.getElementById( 'mwb-tax-select-all' );
+	if ( selectAll ) {
+		selectAll.addEventListener( 'change', function() {
+			document.querySelectorAll( '.mwb-inline-taxonomy__bulk-form input[name="delete_tags[]"]' ).forEach( function( cb ) {
+				cb.checked = selectAll.checked;
+			} );
+		} );
+	}
+} )();
+</script>

--- a/assets/src/back-end/scss/base/_base.scss
+++ b/assets/src/back-end/scss/base/_base.scss
@@ -154,6 +154,31 @@ select {
         justify-content: flex-start;
     }
 
+    .mwb-header-branding {
+        display: flex;
+        align-items: center;
+        gap: 24px;
+        flex-wrap: wrap;
+    }
+
+    .mwb-header-badge {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 42px;
+        padding: 10px 28px;
+        border: 1px solid rgba(255, 255, 255, 0.22);
+        border-radius: 999px;
+        background: linear-gradient(180deg, rgba(255, 255, 255, 0.18) 0%, rgba(255, 255, 255, 0.08) 100%);
+        box-shadow: inset 0 1px 1px rgba(255, 255, 255, 0.16);
+        color: #ffffff;
+        font-family: "NunitoSans-ExtraBold";
+        font-size: 16px;
+        line-height: 1;
+        letter-spacing: 0.5px;
+        text-transform: uppercase;
+    }
+
     .mwb-header-title {
         font-family: "NunitoSans-ExtraBold";
         font-style: normal;
@@ -161,9 +186,9 @@ select {
         font-size: $fs-xmedium;
         line-height: 24px;
         letter-spacing: 0.3px;
-        color: $c-doger-blue;
-        flex: 0 0 100%;
-        max-width: calc(100% - 200px);
+        color: #ffffff;
+        flex: 0 0 auto;
+        max-width: 100%;
         @include media (mwb-phone) {
             max-width: 100%;
         }
@@ -243,9 +268,354 @@ select {
     }
 }
 
-.select2 {
-    &.select2-container {
-        max-width: 100%;
+.wps-field-inline {
+    display: flex;
+    align-items: center;
+    gap: 20px;
+    flex-wrap: wrap;
+}
+
+.wps-select-wrap {
+    position: relative;
+    width: min(100%, 480px);
+    flex: 0 1 480px;
+
+    &::after {
+        content: "";
+        position: absolute;
+        top: 50%;
+        right: 18px;
+        width: 10px;
+        height: 10px;
+        border-right: 2px solid #9a9a9a;
+        border-bottom: 2px solid #9a9a9a;
+        transform: translateY(-65%) rotate(45deg);
+        pointer-events: none;
+    }
+
+    &.wps-select-wrap--multiple::after {
+        display: none;
+    }
+}
+
+.wps-select {
+    width: 100%;
+    min-height: 54px;
+    border: 2px solid #e8cdfd;
+    border-radius: 999px;
+    padding: 12px 46px 12px 22px !important;
+    font-size: 18px;
+    line-height: 1.35;
+    color: #32126d;
+    background-color: #ffffff;
+    font-family: "NunitoSans-Regular", sans-serif;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+    background-image: none;
+    cursor: pointer;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+    outline: none;
+    box-shadow: 0 0 0 5px rgba(232, 205, 253, 0.28);
+
+    &:focus {
+        border-color: #d7b5fb;
+        box-shadow: 0 0 0 6px rgba(215, 181, 251, 0.24);
+    }
+
+    &:hover {
+        border-color: #e0c1fb;
+    }
+
+    option {
+        color: #32126d;
+        font-family: "NunitoSans-Regular", sans-serif;
+    }
+
+    &.wps-select--multiple {
+        min-height: 140px;
+        padding: 14px 16px !important;
+    }
+}
+
+.wps-select-description {
+    flex: 1 1 260px;
+    color: #32126d !important;
+    font-size: 16px;
+    line-height: 1.5;
+}
+
+.wps-time-row {
+    gap: 18px;
+}
+
+.wps-time-input {
+    min-height: 54px;
+    width: min(100%, 360px);
+    flex: 0 1 360px;
+    border: 2px solid #e8cdfd;
+    border-radius: 999px;
+    padding: 12px 22px;
+    font-size: 18px;
+    line-height: 1.35;
+    color: #32126d;
+    background: #ffffff;
+    font-family: "NunitoSans-Regular", sans-serif;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+    outline: none;
+    box-shadow: 0 0 0 5px rgba(232, 205, 253, 0.28);
+
+    &:focus {
+        border-color: #d7b5fb;
+        box-shadow: 0 0 0 6px rgba(215, 181, 251, 0.24);
+    }
+}
+
+.wps-time-description {
+    flex: 1 1 260px;
+    color: #32126d !important;
+    font-size: 16px;
+    line-height: 1.5;
+}
+
+.wps-time-input.wps-daily-time-pill {
+    min-height: 54px;
+    width: min(100%, 360px);
+    flex: 0 1 360px;
+    border: 2px solid #e8cdfd;
+    border-radius: 999px;
+    padding: 12px 22px;
+    font-size: 18px;
+    line-height: 1.35;
+    color: #32126d;
+    background: #ffffff;
+    box-shadow: 0 0 0 5px rgba(232, 205, 253, 0.28);
+
+    &:focus {
+        border-color: #d7b5fb;
+        box-shadow: 0 0 0 6px rgba(215, 181, 251, 0.24);
+    }
+}
+
+.wps-text-input {
+    min-height: 54px;
+    width: min(100%, 360px);
+    flex: 0 1 360px;
+    border: 2px solid #e8cdfd;
+    border-radius: 999px;
+    padding: 12px 22px;
+    font-size: 18px;
+    line-height: 1.35;
+    color: #32126d;
+    background: #ffffff;
+    font-family: "NunitoSans-Regular", sans-serif;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+    outline: none;
+    box-shadow: 0 0 0 5px rgba(232, 205, 253, 0.28);
+
+    &:focus {
+        border-color: #d7b5fb;
+        box-shadow: 0 0 0 6px rgba(215, 181, 251, 0.24);
+    }
+
+    &::placeholder {
+        color: #32126d;
+    }
+}
+
+.wps-select-wrap .select2-container,
+.mwb-form-group__control > .select2-container {
+    width: min(100%, 480px) !important;
+    max-width: 100%;
+    flex: 0 1 480px;
+}
+
+.wps-select-wrap--multiple .select2-container,
+.mwb-defaut-multiselect + .select2-container,
+#mwb_bfwp_order_statuses_to_cancel + .select2-container {
+    width: min(100%, 480px) !important;
+}
+
+.select2-container--default {
+    .select2-selection--single,
+    .select2-selection--multiple {
+        min-height: 54px;
+        border: 2px solid #e8cdfd !important;
+        border-radius: 999px !important;
+        background: #ffffff !important;
+        box-shadow: 0 0 0 5px rgba(232, 205, 253, 0.28) !important;
+        transition: border-color 0.2s ease, box-shadow 0.2s ease;
+    }
+
+    &.select2-container--focus,
+    &.select2-container--open {
+        .select2-selection--single,
+        .select2-selection--multiple {
+            border-color: #d7b5fb !important;
+            box-shadow: 0 0 0 6px rgba(215, 181, 251, 0.24) !important;
+        }
+    }
+
+    .select2-selection--single {
+        &:hover {
+            border-color: #e0c1fb !important;
+        }
+
+        .select2-selection__rendered {
+            padding: 12px 46px 12px 22px;
+            color: #32126d !important;
+            font-family: "NunitoSans-Regular", sans-serif;
+            font-size: 18px;
+            line-height: 1.35;
+        }
+
+        .select2-selection__arrow {
+            height: 100%;
+            width: 42px;
+            right: 0;
+
+            b {
+                border: none;
+                width: 10px;
+                height: 10px;
+                margin: -7px 0 0 -5px;
+                border-right: 2px solid #9a9a9a;
+                border-bottom: 2px solid #9a9a9a;
+                transform: rotate(45deg);
+            }
+        }
+    }
+
+    .select2-selection--multiple {
+        padding: 8px 12px;
+
+        &:hover {
+            border-color: #e0c1fb !important;
+        }
+
+        .select2-selection__rendered {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 8px;
+            padding: 0;
+            white-space: normal;
+        }
+
+        .select2-selection__choice {
+            margin: 0 !important;
+            padding: 6px 10px 6px 24px !important;
+            border: 1px solid #d8cff6 !important;
+            border-radius: 999px !important;
+            background: #f6f2ff !important;
+            color: #32126d !important;
+            font-size: 14px;
+        }
+
+        .select2-selection__choice__remove {
+            left: 8px !important;
+            right: auto !important;
+            top: 50%;
+            margin-top: -9px;
+            border: none !important;
+            color: #7b61c8 !important;
+            font-size: 16px;
+        }
+    }
+}
+
+.select2-container--default .select2-search--inline .select2-search__field {
+    min-height: 32px;
+    margin-top: 0 !important;
+    font-size: 16px;
+    font-family: "NunitoSans-Regular", sans-serif;
+}
+
+.select2-dropdown {
+    border: 1px solid #d8cff6 !important;
+    border-radius: 10px !important;
+    overflow: hidden;
+    box-shadow: 0 10px 24px rgba(50, 18, 109, 0.12);
+}
+
+.select2-results__option {
+    padding: 10px 14px;
+    font-size: 15px;
+    color: #303030;
+}
+
+.select2-container--default .select2-results__option--highlighted[aria-selected],
+.select2-container--default .select2-results__option--highlighted[data-selected] {
+    background: #f6f2ff !important;
+    color: #32126d !important;
+}
+
+.select2-container--default .select2-results__option[aria-selected=true],
+.select2-container--default .select2-results__option[data-selected=true] {
+    background: #ede7ff !important;
+    color: #32126d !important;
+}
+
+.wps_order_status_.wps-calendar-filter-select {
+    min-height: 60px;
+    min-width: 420px;
+    border: 2px solid #e8cdfd !important;
+    border-radius: 999px !important;
+    padding: 10px 56px 10px 26px !important;
+    font-size: 22px !important;
+    line-height: 1.2;
+    color: #32126d !important;
+    background-color: #ffffff !important;
+    background-image: linear-gradient(45deg, transparent 50%, #9f9f9f 50%), linear-gradient(135deg, #9f9f9f 50%, transparent 50%) !important;
+    background-position: calc(100% - 28px) calc(50% - 4px), calc(100% - 18px) calc(50% - 4px) !important;
+    background-size: 10px 10px, 10px 10px !important;
+    background-repeat: no-repeat !important;
+    box-shadow: 0 0 0 7px rgba(232, 205, 253, 0.28);
+    appearance: none;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+
+    &:focus {
+        border-color: #d7b5fb !important;
+        box-shadow: 0 0 0 8px rgba(215, 181, 251, 0.24) !important;
+        outline: none !important;
+    }
+}
+
+.wps-calendar-action-btn.button {
+    min-width: 154px;
+    min-height: 60px;
+    padding: 10px 26px !important;
+    border: 0 !important;
+    border-radius: 999px !important;
+    font-family: "NunitoSans-ExtraBold", sans-serif !important;
+    font-size: 20px !important;
+    line-height: 1.1;
+    letter-spacing: 0.6px;
+    text-shadow: none;
+}
+
+.wps-calendar-action-btn--primary.button {
+    background: #171a33 !important;
+    color: #ffffff !important;
+    box-shadow: 0 12px 24px rgba(23, 26, 51, 0.16);
+
+    &:hover,
+    &:focus {
+        background: #111429 !important;
+        color: #ffffff !important;
+    }
+}
+
+.wps-calendar-action-btn--secondary.button {
+    background: #ffffff !important;
+    color: #32126d !important;
+    border: 2px solid #e8cdfd !important;
+    box-shadow: 0 0 0 6px rgba(232, 205, 253, 0.22);
+
+    &:hover,
+    &:focus {
+        background: #faf5ff !important;
+        color: #32126d !important;
     }
 }
 

--- a/includes/class-mwb-bookings-for-woocommerce-talk-to-expert-form.php
+++ b/includes/class-mwb-bookings-for-woocommerce-talk-to-expert-form.php
@@ -1,0 +1,749 @@
+<?php
+/**
+ * Talk to an Expert HubSpot form handling.
+ *
+ * @package Mwb_Bookings_For_Woocommerce
+ * @subpackage Mwb_Bookings_For_Woocommerce/includes
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( class_exists( 'Mwb_Bookings_For_Woocommerce_Talk_To_Expert_Form' ) ) {
+	return;
+}
+
+/**
+ * Handle the Talk to an Expert custom form lifecycle.
+ */
+class Mwb_Bookings_For_Woocommerce_Talk_To_Expert_Form {
+
+	/**
+	 * Base URL for HubSpot submissions.
+	 *
+	 * @var string
+	 */
+	private $mwb_mbfw_base_url = 'https://api.hsforms.com/';
+
+	/**
+	 * HubSpot portal id.
+	 *
+	 * @var string
+	 */
+	private static $mwb_mbfw_talk_to_expert_portal_id = '25444144';
+
+	/**
+	 * HubSpot form id for the shared Talk to an Expert form.
+	 *
+	 * @var string
+	 */
+	private static $mwb_mbfw_talk_to_expert_form_id = 'eab973a7-5c65-4264-a31d-3b1b10b82c82';
+
+	/**
+	 * Plugin label sent with HubSpot submissions.
+	 *
+	 * @var string
+	 */
+	private static $mwb_mbfw_plugin_name_label = 'Bookings for WooCommerce';
+
+	/**
+	 * Current store name.
+	 *
+	 * @var string
+	 */
+	private static $mwb_mbfw_store_name = '';
+
+	/**
+	 * Current store URL.
+	 *
+	 * @var string
+	 */
+	private static $mwb_mbfw_store_url = '';
+
+	/**
+	 * Register hooks.
+	 */
+	public function __construct() {
+		self::$mwb_mbfw_store_name = get_bloginfo( 'name' );
+		self::$mwb_mbfw_store_url  = home_url();
+
+		add_action( 'admin_footer', array( $this, 'mwb_mbfw_render_talk_to_expert_modal' ) );
+		add_action( 'wp_ajax_mwb_mbfw_submit_talk_to_expert', array( $this, 'mwb_mbfw_submit_talk_to_expert' ) );
+	}
+
+	/**
+	 * Check whether the plugin dashboard screen is active.
+	 *
+	 * @return bool
+	 */
+	private function mwb_mbfw_is_plugin_dashboard_screen() {
+		if ( ! is_admin() ) {
+			return false;
+		}
+
+		$page = isset( $_GET['page'] ) ? sanitize_key( wp_unslash( $_GET['page'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification
+
+		return 'mwb_bookings_for_woocommerce_menu' === $page;
+	}
+
+	/**
+	 * Render the Talk to an Expert modal.
+	 */
+	public function mwb_mbfw_render_talk_to_expert_modal() {
+		if ( ! $this->mwb_mbfw_is_plugin_dashboard_screen() ) {
+			return;
+		}
+
+		$field_values = $this->mwb_mbfw_get_default_field_values();
+		$form_fields  = $this->mwb_mbfw_get_custom_form_fields();
+		?>
+		<div class="mbfw-expert-modal" hidden aria-hidden="true">
+			<div class="mbfw-expert-modal__backdrop" data-mbfw-close-expert-modal="true"></div>
+			<div class="mbfw-expert-modal__dialog" role="dialog" aria-modal="true" aria-labelledby="mbfw-expert-modal-title">
+				<div class="mbfw-expert-modal__header">
+					<div class="mbfw-expert-modal__copy">
+						<h2 id="mbfw-expert-modal-title"><?php esc_html_e( 'Talk to an Expert', 'mwb-bookings-for-woocommerce' ); ?></h2>
+						<p><?php esc_html_e( 'Share your store goals and our team will reach out with the right next step.', 'mwb-bookings-for-woocommerce' ); ?></p>
+					</div>
+					<button type="button" class="mbfw-expert-modal__close" data-mbfw-close-expert-modal="true" aria-label="<?php esc_attr_e( 'Close expert form', 'mwb-bookings-for-woocommerce' ); ?>">
+						<span aria-hidden="true">&times;</span>
+					</button>
+				</div>
+				<div class="mbfw-expert-modal__body">
+					<form class="mbfw-expert-form" data-mbfw-expert-form="true" data-mbfw-expert-form-panel="true" novalidate>
+						<div class="mbfw-expert-form__grid">
+							<?php foreach ( $form_fields as $field_key => $field ) : ?>
+								<?php $this->mwb_mbfw_render_form_field( $field_key, $field, $field_values ); ?>
+							<?php endforeach; ?>
+						</div>
+						<div class="mbfw-expert-form__actions">
+							<button
+								type="submit"
+								class="wps-sidebar-card__expert-btn mbfw-expert-form__submit"
+								data-mbfw-expert-submit="true"
+								data-mbfw-submit-label="<?php echo esc_attr__( 'Submit Request', 'mwb-bookings-for-woocommerce' ); ?>"
+								data-mbfw-submit-loading-label="<?php echo esc_attr__( 'Sending...', 'mwb-bookings-for-woocommerce' ); ?>"
+							>
+								<?php esc_html_e( 'Submit Request', 'mwb-bookings-for-woocommerce' ); ?>
+							</button>
+						</div>
+						<div class="mbfw-expert-form__status" data-mbfw-expert-state="true" hidden></div>
+					</form>
+					<div class="mbfw-expert-thank-you" data-mbfw-expert-thank-you="true" aria-hidden="true" hidden>
+						<div class="mbfw-thank-you-card mbfw-thank-you-card--modal" aria-live="polite">
+							<div class="mbfw-thank-you-card__icon" aria-hidden="true">&#10003;</div>
+							<p class="mbfw-thank-you-card__eyebrow"><?php esc_html_e( 'Talk to an Expert', 'mwb-bookings-for-woocommerce' ); ?></p>
+							<h2 class="mbfw-thank-you-card__title"><?php esc_html_e( 'Thank You', 'mwb-bookings-for-woocommerce' ); ?></h2>
+							<p class="mbfw-thank-you-card__message" data-mbfw-expert-thank-you-message="true"><?php esc_html_e( 'Thank you for submitting your request.', 'mwb-bookings-for-woocommerce' ); ?></p>
+							<p class="mbfw-thank-you-card__meta"><?php esc_html_e( 'Our team will review the details and contact you with the right next step. Redirecting you back to the dashboard in a moment.', 'mwb-bookings-for-woocommerce' ); ?></p>
+							<p class="mbfw-thank-you-card__action">
+								<button type="button" class="wps-sidebar-card__expert-btn" data-mbfw-close-expert-modal="true"><?php esc_html_e( 'Done', 'mwb-bookings-for-woocommerce' ); ?></button>
+							</p>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Build the custom form field definitions.
+	 *
+	 * @return array
+	 */
+	private function mwb_mbfw_get_custom_form_fields() {
+		return array(
+			'firstname' => array(
+				'label'       => esc_html__( 'First Name', 'mwb-bookings-for-woocommerce' ),
+				'type'        => 'text',
+				'placeholder' => esc_html__( 'John', 'mwb-bookings-for-woocommerce' ),
+				'required'    => false,
+			),
+			'lastname'  => array(
+				'label'       => esc_html__( 'Last Name', 'mwb-bookings-for-woocommerce' ),
+				'type'        => 'text',
+				'placeholder' => esc_html__( 'Doe', 'mwb-bookings-for-woocommerce' ),
+				'required'    => false,
+			),
+			'email'      => array(
+				'label'       => esc_html__( 'Work Email', 'mwb-bookings-for-woocommerce' ),
+				'type'        => 'email',
+				'placeholder' => esc_html__( 'name@company.com', 'mwb-bookings-for-woocommerce' ),
+				'required'    => true,
+				'full_width'  => true,
+			),
+			'phone'      => array(
+				'label'       => esc_html__( 'Contact Number', 'mwb-bookings-for-woocommerce' ),
+				'type'        => 'text',
+				'placeholder' => esc_html__( '+1 000 000 0000', 'mwb-bookings-for-woocommerce' ),
+				'required'    => false,
+			),
+			'what_services_do_you_need_help_with' => array(
+				'label'       => esc_html__( 'What services do you need help with?', 'mwb-bookings-for-woocommerce' ),
+				'type'        => 'checkbox_group',
+				'options'     => $this->mwb_mbfw_get_talk_to_expert_service_options(),
+				'required'    => false,
+				'full_width'  => true,
+			),
+			'budget'      => array(
+				'label'       => esc_html__( 'Budget', 'mwb-bookings-for-woocommerce' ),
+				'type'        => 'select',
+				'options'     => $this->mwb_mbfw_get_talk_to_expert_budget_options(),
+				'required'    => false,
+				'full_width'  => true,
+			),
+			'message'    => array(
+				'label'       => esc_html__( 'What do you need help with?', 'mwb-bookings-for-woocommerce' ),
+				'type'        => 'textarea',
+				'placeholder' => esc_html__( 'Share your goals, blockers, or the service you need.', 'mwb-bookings-for-woocommerce' ),
+				'required'    => false,
+				'full_width'  => true,
+			),
+		);
+	}
+
+	/**
+	 * Render an individual form field.
+	 *
+	 * @param string $field_key Field key.
+	 * @param array  $field Field config.
+	 * @param array  $values Default values.
+	 */
+	private function mwb_mbfw_render_form_field( $field_key, $field, $values ) {
+		$field_id    = 'mbfw-expert-' . $field_key;
+		$field_value = isset( $values[ $field_key ] ) ? $values[ $field_key ] : '';
+		$field_class = ! empty( $field['full_width'] ) ? ' mbfw-expert-form__field--full' : '';
+		$field_class .= ' ' . sanitize_html_class( $field_key );
+		?>
+		<div class="mbfw-expert-form__field<?php echo esc_attr( $field_class ); ?>">
+			<?php if ( 'checkbox_group' === $field['type'] ) : ?>
+				<span class="mbfw-expert-form__label">
+					<?php echo esc_html( $field['label'] ); ?>
+					<?php if ( ! empty( $field['required'] ) ) : ?>
+						<span class="mbfw-expert-form__required">*</span>
+					<?php endif; ?>
+				</span>
+				<div id="<?php echo esc_attr( $field_id ); ?>" class="mbfw-expert-form__checkbox-group <?php echo esc_attr( $field_key ); ?>">
+					<?php foreach ( $field['options'] as $option_value => $option_label ) : ?>
+						<?php
+						$option_id = $field_id . '-' . sanitize_title( $option_value );
+						$checked   = is_array( $field_value ) && in_array( $option_value, $field_value, true );
+						?>
+						<label class="mbfw-expert-form__checkbox-label" for="<?php echo esc_attr( $option_id ); ?>">
+							<input
+								id="<?php echo esc_attr( $option_id ); ?>"
+								name="<?php echo esc_attr( $field_key ); ?>[]"
+								type="checkbox"
+								class="mbfw-expert-form__checkbox <?php echo esc_attr( $field_key ); ?>"
+								value="<?php echo esc_attr( $option_value ); ?>"
+								<?php checked( $checked ); ?>
+							/>
+							<span><?php echo esc_html( $option_label ); ?></span>
+						</label>
+					<?php endforeach; ?>
+				</div>
+			<?php else : ?>
+				<label class="mbfw-expert-form__label" for="<?php echo esc_attr( $field_id ); ?>">
+					<?php echo esc_html( $field['label'] ); ?>
+					<?php if ( ! empty( $field['required'] ) ) : ?>
+						<span class="mbfw-expert-form__required">*</span>
+					<?php endif; ?>
+				</label>
+				<?php if ( 'textarea' === $field['type'] ) : ?>
+					<textarea
+						id="<?php echo esc_attr( $field_id ); ?>"
+						name="<?php echo esc_attr( $field_key ); ?>"
+						class="mbfw-expert-form__control mbfw-expert-form__control--textarea <?php echo esc_attr( $field_key ); ?>"
+						placeholder="<?php echo esc_attr( $field['placeholder'] ); ?>"
+						<?php echo ! empty( $field['required'] ) ? 'required' : ''; ?>
+					><?php echo esc_textarea( $field_value ); ?></textarea>
+				<?php elseif ( 'select' === $field['type'] ) : ?>
+					<select
+						id="<?php echo esc_attr( $field_id ); ?>"
+						name="<?php echo esc_attr( $field_key ); ?>"
+						class="mbfw-expert-form__control mbfw-expert-form__control--select <?php echo esc_attr( $field_key ); ?>"
+						<?php echo ! empty( $field['required'] ) ? 'required' : ''; ?>
+					>
+						<?php foreach ( $field['options'] as $option_value => $option_label ) : ?>
+							<option value="<?php echo esc_attr( $option_value ); ?>" <?php selected( $field_value, $option_value ); ?> <?php echo empty( $option_value ) ? 'disabled' : ''; ?>>
+								<?php echo esc_html( $option_label ); ?>
+							</option>
+						<?php endforeach; ?>
+					</select>
+				<?php else : ?>
+					<input
+						id="<?php echo esc_attr( $field_id ); ?>"
+						name="<?php echo esc_attr( $field_key ); ?>"
+						type="<?php echo esc_attr( $field['type'] ); ?>"
+						class="mbfw-expert-form__control <?php echo esc_attr( $field_key ); ?>"
+						value="<?php echo esc_attr( $field_value ); ?>"
+						placeholder="<?php echo esc_attr( $field['placeholder'] ); ?>"
+						<?php echo ! empty( $field['required'] ) ? 'required' : ''; ?>
+					/>
+				<?php endif; ?>
+			<?php endif; ?>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Get the list of available marketing services for the expert form.
+	 *
+	 * @return array
+	 */
+	private function mwb_mbfw_get_talk_to_expert_service_options() {
+		return array(
+			'seo_services'                      => esc_html__( 'SEO services', 'mwb-bookings-for-woocommerce' ),
+			'google_ads_setup_and_ga4_setup'   => esc_html__( 'Google Ads Setup and GA4 setup', 'mwb-bookings-for-woocommerce' ),
+			'speed_optimization'               => esc_html__( 'Speed Optimization', 'mwb-bookings-for-woocommerce' ),
+			'woocommerce_development_services' => esc_html__( 'WooCommerce Development Services', 'mwb-bookings-for-woocommerce' ),
+		);
+	}
+
+	/**
+	 * Get available budget options for the expert form.
+	 *
+	 * @return array
+	 */
+	private function mwb_mbfw_get_talk_to_expert_budget_options() {
+		return array(
+			''            => 'Please Select',
+			'500-1000'    => '$500 - $1000',
+			'1001-5000'   => '$1001 - $5000',
+			'5001-10000'  => '$5001 - $10000',
+			'10001-15000' => '$10001 - $15000',
+		);
+	}
+
+	/**
+	 * Get default values from the current user and site context.
+	 *
+	 * @return array
+	 */
+	private function mwb_mbfw_get_default_field_values() {
+		$current_user = wp_get_current_user();
+		$first_name   = '';
+		$last_name    = '';
+
+		if ( ! empty( $current_user->first_name ) || ! empty( $current_user->last_name ) ) {
+			$first_name = $current_user->first_name;
+			$last_name  = $current_user->last_name;
+		} elseif ( ! empty( $current_user->display_name ) ) {
+			$name_parts = preg_split( '/\s+/', trim( $current_user->display_name ), 2 );
+			$first_name = ! empty( $name_parts[0] ) ? $name_parts[0] : '';
+			$last_name  = ! empty( $name_parts[1] ) ? $name_parts[1] : '';
+		}
+
+		return array(
+			'firstname'                       => $first_name,
+			'lastname'                        => $last_name,
+			'email'                           => ! empty( $current_user->user_email ) ? $current_user->user_email : '',
+			'phone'                           => '',
+			'what_services_do_you_need_help_with' => array(),
+			'budget'                          => '',
+			'message'                         => '',
+		);
+	}
+
+	/**
+	 * AJAX handler for HubSpot form submission.
+	 */
+	public function mwb_mbfw_submit_talk_to_expert() {
+		check_ajax_referer( 'mwb_mbfw_talk_to_expert_nonce', 'nonce' );
+
+		if ( ! current_user_can( 'manage_options' ) && ! current_user_can( 'manage_woocommerce' ) ) {
+			wp_send_json_error(
+				array(
+					'message' => esc_html__( 'You are not allowed to submit this request.', 'mwb-bookings-for-woocommerce' ),
+				),
+				403
+			);
+		}
+
+		$form_payload = isset( $_POST['form_data'] ) ? wp_unslash( $_POST['form_data'] ) : '';
+		$form_data    = ! empty( $form_payload ) ? json_decode( $form_payload, true ) : array();
+
+		if ( empty( $form_data ) || ! is_array( $form_data ) ) {
+			wp_send_json_error(
+				array(
+					'message' => esc_html__( 'The request could not be processed. Please try again.', 'mwb-bookings-for-woocommerce' ),
+				),
+				400
+			);
+		}
+
+		$sanitized_data = $this->mwb_mbfw_sanitize_talk_to_expert_data( $form_data );
+
+		if ( empty( $sanitized_data['email'] ) || ! is_email( $sanitized_data['email'] ) ) {
+			wp_send_json_error(
+				array(
+					'message' => esc_html__( 'Please enter a valid email address.', 'mwb-bookings-for-woocommerce' ),
+				),
+				422
+			);
+		}
+
+		$result = $this->mwb_mbfw_submit_hubspot_form(
+			array_filter(
+				array(
+					$this->mwb_mbfw_prepare_hubspot_field( 'firstname', $sanitized_data['firstname'] ),
+					$this->mwb_mbfw_prepare_hubspot_field( 'lastname', $sanitized_data['lastname'] ),
+					$this->mwb_mbfw_prepare_hubspot_field( 'email', $sanitized_data['email'] ),
+					$this->mwb_mbfw_prepare_hubspot_field( 'phone', $sanitized_data['phone'] ),
+					$this->mwb_mbfw_prepare_hubspot_field( 'what_services_do_you_need_help_with', $sanitized_data['what_services_do_you_need_help_with'] ),
+					$this->mwb_mbfw_prepare_hubspot_field( 'budget', $sanitized_data['budget'] ),
+					$this->mwb_mbfw_prepare_hubspot_field( 'message', $sanitized_data['message'] ),
+					$this->mwb_mbfw_prepare_hubspot_field( 'currency', $this->mwb_mbfw_get_store_currency() ),
+					$this->mwb_mbfw_prepare_hubspot_field( 'org_plugin_name', self::$mwb_mbfw_plugin_name_label ),
+					$this->mwb_mbfw_prepare_hubspot_field( 'company', self::$mwb_mbfw_store_name ),
+					$this->mwb_mbfw_prepare_hubspot_field( 'website', self::$mwb_mbfw_store_url ),
+					$this->mwb_mbfw_prepare_hubspot_field( 'country', $this->mwb_mbfw_get_store_country() ),
+					$this->mwb_mbfw_prepare_hubspot_field( 'annualrevenue', $this->mwb_mbfw_get_store_annual_revenue() ),
+				)
+			)
+		);
+
+		if ( empty( $result['success'] ) ) {
+			wp_send_json_error(
+				array(
+					'message' => $result['message'],
+				),
+				500
+			);
+		}
+
+		wp_send_json_success(
+			array(
+				'message' => $result['message'],
+			)
+		);
+	}
+
+	/**
+	 * Get the Talk to an Expert dashboard URL.
+	 *
+	 * @return string
+	 */
+	private function mwb_mbfw_get_talk_to_expert_dashboard_url() {
+		return admin_url( 'admin.php?page=mwb_bookings_for_woocommerce_menu' );
+	}
+
+	/**
+	 * Sanitize form data.
+	 *
+	 * @param array $form_data Raw request data.
+	 * @return array
+	 */
+	private function mwb_mbfw_sanitize_talk_to_expert_data( $form_data ) {
+		$allowed_services  = array_keys( $this->mwb_mbfw_get_talk_to_expert_service_options() );
+		$allowed_budgets   = array_keys( $this->mwb_mbfw_get_talk_to_expert_budget_options() );
+		$selected_services = isset( $form_data['what_services_do_you_need_help_with'] ) ? (array) $form_data['what_services_do_you_need_help_with'] : array();
+		$selected_services = array_map( 'sanitize_text_field', $selected_services );
+		$selected_services = array_values(
+			array_filter(
+				$selected_services,
+				function ( $service ) use ( $allowed_services ) {
+					return in_array( $service, $allowed_services, true );
+				}
+			)
+		);
+		$budget = isset( $form_data['budget'] ) ? sanitize_text_field( $form_data['budget'] ) : '';
+		$budget = in_array( $budget, $allowed_budgets, true ) ? $budget : '';
+
+		return array(
+			'firstname'                       => isset( $form_data['firstname'] ) ? sanitize_text_field( $form_data['firstname'] ) : '',
+			'lastname'                        => isset( $form_data['lastname'] ) ? sanitize_text_field( $form_data['lastname'] ) : '',
+			'email'                           => isset( $form_data['email'] ) ? sanitize_email( $form_data['email'] ) : '',
+			'phone'                           => isset( $form_data['phone'] ) ? sanitize_text_field( $form_data['phone'] ) : '',
+			'what_services_do_you_need_help_with' => $selected_services,
+			'budget'                          => isset( $form_data['budget'] ) ? $budget : '',
+			'message'                         => isset( $form_data['message'] ) ? sanitize_textarea_field( $form_data['message'] ) : '',
+		);
+	}
+
+	/**
+	 * Prepare a HubSpot field payload.
+	 *
+	 * @param string       $field_name HubSpot field name.
+	 * @param string|array $field_value Field value.
+	 * @return array|null
+	 */
+	private function mwb_mbfw_prepare_hubspot_field( $field_name, $field_value ) {
+		if ( is_array( $field_value ) ) {
+			$field_value = implode( ';', $field_value );
+		}
+
+		if ( 'Please Select' === $field_value ) {
+			return null;
+		}
+
+		if ( '' === $field_value || null === $field_value ) {
+			return null;
+		}
+
+		return array(
+			'name'  => $field_name,
+			'value' => $field_value,
+		);
+	}
+
+	/**
+	 * Get the store currency code.
+	 *
+	 * @return string
+	 */
+	private function mwb_mbfw_get_store_currency() {
+		if ( function_exists( 'get_woocommerce_currency' ) ) {
+			return get_woocommerce_currency();
+		}
+
+		return '';
+	}
+
+	/**
+	 * Get the store country label.
+	 *
+	 * @return string
+	 */
+	private function mwb_mbfw_get_store_country() {
+		$default_country = get_option( 'woocommerce_default_country', '' );
+		$country_parts   = explode( ':', $default_country );
+		$country_code    = ! empty( $country_parts[0] ) ? $country_parts[0] : '';
+
+		if ( empty( $country_code ) ) {
+			return '';
+		}
+
+		if ( class_exists( 'WC_Countries' ) ) {
+			$countries = new WC_Countries();
+			if ( isset( $countries->countries[ $country_code ] ) ) {
+				return $countries->countries[ $country_code ];
+			}
+		}
+
+		return $country_code;
+	}
+
+	/**
+	 * Get the store revenue for the last 12 months of paid orders.
+	 *
+	 * @return string
+	 */
+	private function mwb_mbfw_get_store_annual_revenue() {
+		$stats_revenue = $this->mwb_mbfw_get_store_annual_revenue_from_stats();
+
+		if ( null !== $stats_revenue ) {
+			return $stats_revenue;
+		}
+
+		return $this->mwb_mbfw_get_store_annual_revenue_from_orders();
+	}
+
+	/**
+	 * Get annual revenue from WooCommerce analytics order stats when available.
+	 *
+	 * @return string|null
+	 */
+	private function mwb_mbfw_get_store_annual_revenue_from_stats() {
+		global $wpdb;
+
+		if ( ! function_exists( 'wc_get_is_paid_statuses' ) || ! isset( $wpdb ) || empty( $wpdb->prefix ) ) {
+			return null;
+		}
+
+		$table_name = $wpdb->prefix . 'wc_order_stats';
+
+		if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table_name ) ) !== $table_name ) {
+			return null;
+		}
+
+		$paid_statuses = array_map(
+			function ( $status ) {
+				return 0 === strpos( $status, 'wc-' ) ? $status : 'wc-' . $status;
+			},
+			(array) wc_get_is_paid_statuses()
+		);
+
+		if ( empty( $paid_statuses ) ) {
+			return null;
+		}
+
+		$placeholders = implode( ', ', array_fill( 0, count( $paid_statuses ), '%s' ) );
+		$cutoff_date  = gmdate( 'Y-m-d H:i:s', strtotime( '-12 months' ) );
+		$query        = "
+			SELECT COALESCE(SUM(total_sales), 0)
+			FROM {$table_name}
+			WHERE status IN ({$placeholders})
+				AND parent_id = 0
+				AND date_paid IS NOT NULL
+				AND date_paid != '0000-00-00 00:00:00'
+				AND date_paid >= %s
+		";
+		$revenue      = $wpdb->get_var( $wpdb->prepare( $query, array_merge( $paid_statuses, array( $cutoff_date ) ) ) );
+
+		if ( ! is_numeric( $revenue ) ) {
+			return null;
+		}
+
+		return number_format( (float) $revenue, 2, '.', '' );
+	}
+
+	/**
+	 * Fallback annual revenue using WooCommerce order queries.
+	 *
+	 * @return string
+	 */
+	private function mwb_mbfw_get_store_annual_revenue_from_orders() {
+		if ( ! function_exists( 'wc_get_orders' ) || ! function_exists( 'wc_get_is_paid_statuses' ) ) {
+			return '';
+		}
+
+		$orders = wc_get_orders(
+			array(
+				'status'    => array_values( (array) wc_get_is_paid_statuses() ),
+				'type'      => 'shop_order',
+				'limit'     => -1,
+				'date_paid' => '>' . gmdate( 'Y-m-d H:i:s', strtotime( '-12 months' ) ),
+				'return'    => 'objects',
+			)
+		);
+
+		$total_revenue = 0.0;
+
+		foreach ( $orders as $order ) {
+			if ( is_object( $order ) && method_exists( $order, 'get_total' ) ) {
+				$total_revenue += (float) $order->get_total();
+			}
+		}
+
+		return number_format( $total_revenue, 2, '.', '' );
+	}
+
+	/**
+	 * Submit the payload to HubSpot.
+	 *
+	 * @param array $fields Form fields.
+	 * @return array
+	 */
+	private function mwb_mbfw_submit_hubspot_form( $fields ) {
+		$fields = array_values( array_filter( $fields ) );
+
+		$url     = $this->mwb_mbfw_base_url . 'submissions/v3/integration/submit/' . self::$mwb_mbfw_talk_to_expert_portal_id . '/' . self::$mwb_mbfw_talk_to_expert_form_id;
+		$request = array(
+			'method'      => 'POST',
+			'timeout'     => 45,
+			'redirection' => 5,
+			'httpversion' => '1.0',
+			'blocking'    => true,
+			'headers'     => array(
+				'Content-Type' => 'application/json',
+			),
+			'body'        => wp_json_encode(
+				array(
+					'fields'  => $fields,
+					'context' => array(
+						'pageUri'   => $this->mwb_mbfw_get_talk_to_expert_dashboard_url(),
+						'pageName'  => self::$mwb_mbfw_store_name,
+						'ipAddress' => $this->mwb_mbfw_get_client_ip(),
+					),
+				)
+			),
+			'cookies'     => array(),
+		);
+
+		$response = wp_remote_post( $url, $request );
+
+		if ( is_wp_error( $response ) ) {
+			return array(
+				'success' => false,
+				'message' => esc_html__( 'The request could not be sent right now. Please try again shortly.', 'mwb-bookings-for-woocommerce' ),
+			);
+		}
+
+		$status_code = wp_remote_retrieve_response_code( $response );
+		$body        = wp_remote_retrieve_body( $response );
+		$decoded     = json_decode( $body, true );
+
+		if ( 200 === (int) $status_code ) {
+			return array(
+				'success' => true,
+				'message' => $this->mwb_mbfw_get_success_message( $decoded ),
+			);
+		}
+
+		return array(
+			'success' => false,
+			'message' => $this->mwb_mbfw_get_error_message( $decoded ),
+		);
+	}
+
+	/**
+	 * Get a readable success message from the HubSpot response.
+	 *
+	 * @param array $response Decoded API response.
+	 * @return string
+	 */
+	private function mwb_mbfw_get_success_message( $response ) {
+		if ( ! empty( $response['inlineMessage'] ) ) {
+			$message = wp_strip_all_tags( $response['inlineMessage'] );
+			$message = html_entity_decode( $message, ENT_QUOTES | ENT_HTML5, 'UTF-8' );
+			$message = preg_replace( '/[\s\x{00A0}]+/u', ' ', $message );
+			$message = trim( $message );
+
+			if ( ! empty( $message ) ) {
+				return $message;
+			}
+		}
+
+		return esc_html__( 'Thank you for submitting your request. Our team will contact you soon.', 'mwb-bookings-for-woocommerce' );
+	}
+
+	/**
+	 * Get a readable error message from the HubSpot response.
+	 *
+	 * @param array $response Decoded API response.
+	 * @return string
+	 */
+	private function mwb_mbfw_get_error_message( $response ) {
+		if ( ! empty( $response['errors'] ) && is_array( $response['errors'] ) ) {
+			$first_error = reset( $response['errors'] );
+
+			if ( ! empty( $first_error['message'] ) ) {
+				return sanitize_text_field( $first_error['message'] );
+			}
+		}
+
+		if ( ! empty( $response['message'] ) ) {
+			return sanitize_text_field( $response['message'] );
+		}
+
+		return esc_html__( 'Something went wrong while submitting the form. Please try again.', 'mwb-bookings-for-woocommerce' );
+	}
+
+	/**
+	 * Get the current client IP.
+	 *
+	 * @return string
+	 */
+	private function mwb_mbfw_get_client_ip() {
+		$ipaddress = '';
+
+		if ( getenv( 'HTTP_CLIENT_IP' ) ) {
+			$ipaddress = getenv( 'HTTP_CLIENT_IP' );
+		} elseif ( getenv( 'HTTP_X_FORWARDED_FOR' ) ) {
+			$ipaddress = getenv( 'HTTP_X_FORWARDED_FOR' );
+		} elseif ( getenv( 'HTTP_X_FORWARDED' ) ) {
+			$ipaddress = getenv( 'HTTP_X_FORWARDED' );
+		} elseif ( getenv( 'HTTP_FORWARDED_FOR' ) ) {
+			$ipaddress = getenv( 'HTTP_FORWARDED_FOR' );
+		} elseif ( getenv( 'HTTP_FORWARDED' ) ) {
+			$ipaddress = getenv( 'HTTP_FORWARDED' );
+		} elseif ( getenv( 'REMOTE_ADDR' ) ) {
+			$ipaddress = getenv( 'REMOTE_ADDR' );
+		}
+
+		return $ipaddress;
+	}
+}

--- a/includes/class-mwb-bookings-for-woocommerce.php
+++ b/includes/class-mwb-bookings-for-woocommerce.php
@@ -133,6 +133,7 @@ class Mwb_Bookings_For_Woocommerce {
 
 			// The class responsible for defining all actions that occur in the admin area.
 			include_once plugin_dir_path( dirname( __FILE__ ) ) . 'admin/class-mwb-bookings-for-woocommerce-admin.php';
+			include_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/class-mwb-bookings-for-woocommerce-talk-to-expert-form.php';
 
 			// The class responsible for on-boarding steps for plugin.
 			if ( is_dir( plugin_dir_path( dirname( __FILE__ ) ) . 'onboarding' ) && ! class_exists( 'Mwb_Bookings_For_Woocommerce_Onboarding_Steps' ) ) {
@@ -181,6 +182,7 @@ class Mwb_Bookings_For_Woocommerce {
 	 */
 	private function mwb_bookings_for_woocommerce_admin_hooks() {
 		$mbfw_plugin_admin = new Mwb_Bookings_For_Woocommerce_Admin( $this->mbfw_get_plugin_name(), $this->mbfw_get_version() );
+		new Mwb_Bookings_For_Woocommerce_Talk_To_Expert_Form();
 
 		$this->loader->add_action( 'admin_enqueue_scripts', $mbfw_plugin_admin, 'mbfw_admin_enqueue_styles' );
 		$this->loader->add_action( 'admin_enqueue_scripts', $mbfw_plugin_admin, 'mbfw_admin_enqueue_scripts' );
@@ -425,6 +427,12 @@ class Mwb_Bookings_For_Woocommerce {
 	public function mwb_mbfw_plug_default_tabs() {
 		$mbfw_default_tabs = array();
 
+		$mbfw_default_tabs['mwb-bookings-for-woocommerce-overview'] = array(
+			'title'     => esc_html__( 'Overview', 'mwb-bookings-for-woocommerce' ),
+			'name'      => 'mwb-bookings-for-woocommerce-overview',
+			'file_path' => MWB_BOOKINGS_FOR_WOOCOMMERCE_DIR_PATH . 'admin/partials/mwb-bookings-for-woocommerce-overview.php',
+		);
+
 		$mbfw_default_tabs['mwb-bookings-for-woocommerce-general'] = array(
 			'title'     => esc_html__( 'General Settings', 'mwb-bookings-for-woocommerce' ),
 			'name'      => 'mwb-bookings-for-woocommerce-general',
@@ -454,11 +462,6 @@ class Mwb_Bookings_For_Woocommerce {
 			'title'     => esc_html__( 'Availability Settings', 'mwb-bookings-for-woocommerce' ),
 			'name'      => 'mwb-bookings-for-woocommerce-booking-availability-settings',
 			'file_path' => MWB_BOOKINGS_FOR_WOOCOMMERCE_DIR_PATH . 'admin/partials/mwb-bookings-for-woocommerce-booking-availability-settings.php',
-		);
-		$mbfw_default_tabs['mwb-bookings-for-woocommerce-overview'] = array(
-			'title'     => esc_html__( 'Overview', 'mwb-bookings-for-woocommerce' ),
-			'name'      => 'mwb-bookings-for-woocommerce-overview',
-			'file_path' => MWB_BOOKINGS_FOR_WOOCOMMERCE_DIR_PATH . 'admin/partials/mwb-bookings-for-woocommerce-overview.php',
 		);
 		return $mbfw_default_tabs;
 	}
@@ -559,35 +562,26 @@ class Mwb_Bookings_For_Woocommerce {
 									<label for="<?php echo esc_attr( $mbfw_component['id'] ); ?>" class="mwb-form-label"><?php echo ( isset( $mbfw_component['title'] ) ? esc_html( $mbfw_component['title'] ) : '' ); ?></label>
 								</div>
 								<div class="mwb-form-group__control">
-									<label class="mdc-text-field mdc-text-field--outlined">
-										<span class="mdc-notched-outline">
-											<span class="mdc-notched-outline__leading"></span>
-											<span class="mdc-notched-outline__notch">
-												<?php if ( 'number' !== $mbfw_component['type'] ) { ?>
-													<span class="mdc-floating-label" id="my-label-id" style=""><?php echo ( isset( $mbfw_component['placeholder'] ) ? esc_attr( $mbfw_component['placeholder'] ) : '' ); ?></span>
-												<?php } ?>
-											</span>
-											<span class="mdc-notched-outline__trailing"></span>
-										</span>
+									<div class="wps-field-inline">
 										<input
-										class="mdc-text-field__input <?php echo ( isset( $mbfw_component['class'] ) ? esc_attr( $mbfw_component['class'] ) : '' ); ?>" 
-										name="<?php echo ( isset( $mbfw_component['name'] ) ? esc_html( $mbfw_component['name'] ) : esc_html( $mbfw_component['id'] ) ); ?>"
-										id="<?php echo esc_attr( $mbfw_component['id'] ); ?>"
-										type="<?php echo esc_attr( $mbfw_component['type'] ); ?>"
-										value="<?php echo ( isset( $mbfw_component['value'] ) ? esc_attr( $mbfw_component['value'] ) : '' ); ?>"
-										placeholder="<?php echo ( isset( $mbfw_component['placeholder'] ) ? esc_attr( $mbfw_component['placeholder'] ) : '' ); ?>"
-										<?php
-										if ( isset( $mbfw_component['custom_attribute'] ) ) {
-											$custom_attributes = $mbfw_component['custom_attribute'];
-											foreach ( $custom_attributes as $attr_key => $attr_val ) {
-												echo esc_attr( $attr_key . '=' . $attr_val . ' ' );
+											class="wps-text-input <?php echo ( isset( $mbfw_component['class'] ) ? esc_attr( $mbfw_component['class'] ) : '' ); ?>"
+											name="<?php echo ( isset( $mbfw_component['name'] ) ? esc_html( $mbfw_component['name'] ) : esc_html( $mbfw_component['id'] ) ); ?>"
+											id="<?php echo esc_attr( $mbfw_component['id'] ); ?>"
+											type="<?php echo esc_attr( $mbfw_component['type'] ); ?>"
+											value="<?php echo ( isset( $mbfw_component['value'] ) ? esc_attr( $mbfw_component['value'] ) : '' ); ?>"
+											placeholder="<?php echo ( isset( $mbfw_component['placeholder'] ) ? esc_attr( $mbfw_component['placeholder'] ) : '' ); ?>"
+											<?php
+											if ( isset( $mbfw_component['custom_attribute'] ) ) {
+												$custom_attributes = $mbfw_component['custom_attribute'];
+												foreach ( $custom_attributes as $attr_key => $attr_val ) {
+													echo esc_attr( $attr_key . '=' . $attr_val . ' ' );
+												}
 											}
-										}
-										?>
+											?>
 										>
-									</label>
-									<div class="mdc-text-field-helper-line">
-										<div class="mdc-text-field-helper-text--persistent mwb-helper-text" id="" aria-hidden="true"><?php echo ( isset( $mbfw_component['description'] ) ? esc_attr( $mbfw_component['description'] ) : '' ); ?></div>
+										<?php if ( ! empty( $mbfw_component['description'] ) ) { ?>
+											<span class="wps-helper-text"><?php echo esc_html( $mbfw_component['description'] ); ?></span>
+										<?php } ?>
 									</div>
 								</div>
 							</div>
@@ -658,32 +652,34 @@ class Mwb_Bookings_For_Woocommerce {
 									<label class="mwb-form-label" for="<?php echo esc_attr( $mbfw_component['id'] ); ?>"><?php echo ( isset( $mbfw_component['title'] ) ? esc_html( $mbfw_component['title'] ) : '' ); ?></label>
 								</div>
 								<div class="mwb-form-group__control">
-									<div class="mwb-form-select">
-										<select id="<?php echo esc_attr( $mbfw_component['id'] ); ?>" name="<?php echo ( isset( $mbfw_component['name'] ) ? esc_html( $mbfw_component['name'] ) : esc_html( $mbfw_component['id'] ) ); ?><?php echo ( 'multiselect' === $mbfw_component['type'] ) ? '[]' : ''; ?>" id="<?php echo esc_attr( $mbfw_component['id'] ); ?>" class="mdl-textfield__input <?php echo ( isset( $mbfw_component['class'] ) ? esc_attr( $mbfw_component['class'] ) : '' ); ?>" <?php echo 'multiselect' === $mbfw_component['type'] ? 'multiple="multiple"' : ''; ?> >
-											<?php
-
-											foreach ( $mbfw_component['options'] as $mbfw_key => $mbfw_val ) {
-												?>
-												<option value="<?php echo esc_attr( $mbfw_key ); ?>"
-													<?php
-													if ( is_array( $mbfw_component['value'] ) ) {
-														selected( in_array( (string) $mbfw_key, $mbfw_component['value'], true ), true );
-													} else {
-														selected( $mbfw_component['value'], (string) $mbfw_key );
-													}
-													?>
-													>
-													<?php echo esc_html( $mbfw_val ); ?>
-												</option>
-												<?php
-											}
-											?>
-										</select>
-										<label class="mdl-textfield__label" for="<?php echo esc_attr( $mbfw_component['id'] ); ?>"><?php echo esc_html( $mbfw_component['description'] ); ?></label>
+									<div class="wps-field-inline">
+										<div class="wps-select-wrap<?php echo 'multiselect' === $mbfw_component['type'] ? ' wps-select-wrap--multiple' : ''; ?>">
+											<select
+												class="wps-select <?php echo 'multiselect' === $mbfw_component['type'] ? 'wps-select--multiple ' : ''; ?><?php echo ( isset( $mbfw_component['class'] ) ? esc_attr( $mbfw_component['class'] ) : '' ); ?>"
+												id="<?php echo esc_attr( $mbfw_component['id'] ); ?>"
+												name="<?php echo ( isset( $mbfw_component['name'] ) ? esc_html( $mbfw_component['name'] ) : esc_html( $mbfw_component['id'] ) ); ?><?php echo ( 'multiselect' === $mbfw_component['type'] ) ? '[]' : ''; ?>"
+												<?php echo 'multiselect' === $mbfw_component['type'] ? 'multiple="multiple"' : ''; ?>
+											>
+												<?php foreach ( $mbfw_component['options'] as $mbfw_key => $mbfw_val ) { ?>
+													<option value="<?php echo esc_attr( $mbfw_key ); ?>"
+														<?php
+														if ( is_array( $mbfw_component['value'] ) ) {
+															selected( in_array( (string) $mbfw_key, $mbfw_component['value'], true ), true );
+														} else {
+															selected( $mbfw_component['value'], (string) $mbfw_key );
+														}
+														?>
+													><?php echo esc_html( $mbfw_val ); ?></option>
+												<?php } ?>
+											</select>
+										</div>
+										<?php if ( ! empty( $mbfw_component['description'] ) ) { ?>
+											<span class="wps-helper-text wps-select-description"><?php echo esc_html( $mbfw_component['description'] ); ?></span>
+										<?php } ?>
 									</div>
 								</div>
 							</div>
-								<?php
+							<?php
 							break;
 
 						case 'checkbox':
@@ -692,30 +688,26 @@ class Mwb_Bookings_For_Woocommerce {
 								<div class="mwb-form-group__label">
 									<label for="<?php echo esc_attr( $mbfw_component['id'] ); ?>" class="mwb-form-label"><?php echo ( isset( $mbfw_component['title'] ) ? esc_html( $mbfw_component['title'] ) : '' ); ?></label>
 								</div>
-								<div class="mwb-form-group__control mwb-pl-4">
-									<div class="mdc-form-field">
-										<div class="mdc-checkbox">
-											<input 
-											name="<?php echo ( isset( $mbfw_component['name'] ) ? esc_html( $mbfw_component['name'] ) : esc_html( $mbfw_component['id'] ) ); ?>"
-											id="<?php echo esc_attr( $mbfw_component['id'] ); ?>"
-											type="checkbox"
-											class="mdc-checkbox__native-control <?php echo ( isset( $mbfw_component['class'] ) ? esc_attr( $mbfw_component['class'] ) : '' ); ?>"
-											value="<?php echo ( isset( $mbfw_component['value'] ) ? esc_attr( $mbfw_component['value'] ) : '' ); ?>"
-											<?php checked( $mbfw_component['value'], '1' ); ?>
-											/>
-											<div class="mdc-checkbox__background">
-												<svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
-													<path class="mdc-checkbox__checkmark-path" fill="none" d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
-												</svg>
-												<div class="mdc-checkbox__mixedmark"></div>
-											</div>
-											<div class="mdc-checkbox__ripple"></div>
-										</div>
-										<label for="checkbox-1"><?php echo ( isset( $mbfw_component['description'] ) ? esc_attr( $mbfw_component['description'] ) : '' ); ?></label>
+								<div class="mwb-form-group__control">
+									<div class="wps-field-inline">
+										<label class="wps-checkbox">
+											<input
+												type="checkbox"
+												name="<?php echo ( isset( $mbfw_component['name'] ) ? esc_html( $mbfw_component['name'] ) : esc_html( $mbfw_component['id'] ) ); ?>"
+												id="<?php echo esc_attr( $mbfw_component['id'] ); ?>"
+												class="wps-checkbox__input <?php echo ( isset( $mbfw_component['class'] ) ? esc_attr( $mbfw_component['class'] ) : '' ); ?>"
+												value="<?php echo ( isset( $mbfw_component['value'] ) ? esc_attr( $mbfw_component['value'] ) : '' ); ?>"
+												<?php checked( $mbfw_component['value'], '1' ); ?>
+											>
+											<span class="wps-checkbox__box"></span>
+										</label>
+										<?php if ( ! empty( $mbfw_component['description'] ) ) { ?>
+											<span class="wps-helper-text"><?php echo esc_html( $mbfw_component['description'] ); ?></span>
+										<?php } ?>
 									</div>
 								</div>
 							</div>
-								<?php
+							<?php
 							break;
 
 						case 'radio':
@@ -759,33 +751,30 @@ class Mwb_Bookings_For_Woocommerce {
 							?>
 							<div class="mwb-form-group">
 								<div class="mwb-form-group__label">
-									<label for="" class="mwb-form-label"><?php echo ( isset( $mbfw_component['title'] ) ? esc_html( $mbfw_component['title'] ) : '' ); ?></label>
+									<label class="mwb-form-label"><?php echo ( isset( $mbfw_component['title'] ) ? esc_html( $mbfw_component['title'] ) : '' ); ?></label>
 								</div>
 								<div class="mwb-form-group__control">
-									<div>
-										<div class="mdc-switch">
-											<div class="mdc-switch__track"></div>
-											<div class="mdc-switch__thumb-underlay">
-												<div class="mdc-switch__thumb"></div>
-												<input
-												name="<?php echo ( isset( $mbfw_component['name'] ) ? esc_html( $mbfw_component['name'] ) : esc_html( $mbfw_component['id'] ) ); ?>"
+									<div class="wps-toggle-wrap">
+										<label class="wps-toggle">
+											<input
 												type="checkbox"
+												name="<?php echo ( isset( $mbfw_component['name'] ) ? esc_html( $mbfw_component['name'] ) : esc_html( $mbfw_component['id'] ) ); ?>"
 												id="<?php echo esc_html( $mbfw_component['id'] ); ?>"
 												value="yes"
-												class="mdc-switch__native-control <?php echo ( isset( $mbfw_component['class'] ) ? esc_attr( $mbfw_component['class'] ) : '' ); ?>"
-												role="switch" 
-												aria-checked="<?php echo esc_html( 'yes' === $mbfw_component['value'] ) ? 'true' : 'false'; ?>"
+												class="wps-toggle__input <?php echo ( isset( $mbfw_component['class'] ) ? esc_attr( $mbfw_component['class'] ) : '' ); ?>"
+												role="switch"
+												aria-checked="<?php echo ( 'yes' === $mbfw_component['value'] ) ? 'true' : 'false'; ?>"
 												<?php checked( $mbfw_component['value'], 'yes' ); ?>
-												>
-											</div>
-										</div>
-									</div>
-									<div class="mdc-text-field-helper-line">
-										<div class="mdc-text-field-helper-text--persistent mwb-helper-text" id="" aria-hidden="true"><?php echo ( isset( $mbfw_component['description'] ) ? wp_kses_post( $mbfw_component['description'] ) : '' ); ?></div>
+											>
+											<span class="wps-toggle__slider"></span>
+										</label>
+										<?php if ( ! empty( $mbfw_component['description'] ) ) { ?>
+											<span class="wps-helper-text"><?php echo wp_kses_post( $mbfw_component['description'] ); ?></span>
+										<?php } ?>
 									</div>
 								</div>
 							</div>
-								<?php
+							<?php
 							break;
 
 						case 'button':
@@ -842,8 +831,38 @@ class Mwb_Bookings_For_Woocommerce {
 							<?php
 							break;
 						case 'color':
+							$mbfw_color_value = isset( $mbfw_component['value'] ) ? esc_attr( $mbfw_component['value'] ) : '#000000';
+							?>
+							<div class="mwb-form-group mwb-mbfw-color">
+								<div class="mwb-form-group__label">
+									<label for="<?php echo esc_attr( $mbfw_component['id'] ); ?>" class="mwb-form-label"><?php echo ( isset( $mbfw_component['title'] ) ? esc_html( $mbfw_component['title'] ) : '' ); ?></label>
+								</div>
+								<div class="mwb-form-group__control">
+									<div class="mwb-color-input-wrap">
+										<input
+											type="color"
+											class="mwb-color-swatch-input <?php echo ( isset( $mbfw_component['class'] ) ? esc_attr( $mbfw_component['class'] ) : '' ); ?>"
+											name="<?php echo ( isset( $mbfw_component['name'] ) ? esc_html( $mbfw_component['name'] ) : esc_html( $mbfw_component['id'] ) ); ?>"
+											id="<?php echo esc_attr( $mbfw_component['id'] ); ?>"
+											value="<?php echo $mbfw_color_value; ?>"
+											autocomplete="off"
+										>
+										<div class="mwb-color-input-details">
+											<div class="mwb-color-input-top-row">
+												<span class="mwb-color-badge"><?php esc_html_e( 'COLOR', 'mwb-bookings-for-woocommerce' ); ?></span>
+												<span class="mwb-color-hex-display" id="<?php echo esc_attr( $mbfw_component['id'] ); ?>_hex_display"><?php echo esc_html( strtoupper( $mbfw_color_value ) ); ?></span>
+											</div>
+											<?php if ( ! empty( $mbfw_component['description'] ) ) { ?>
+												<span class="mwb-color-input-description"><?php echo esc_html( $mbfw_component['description'] ); ?></span>
+											<?php } ?>
+										</div>
+									</div>
+								</div>
+							</div>
+							<?php
+							break;
+
 						case 'date':
-						case 'file':
 						case 'time':
 							?>
 							<div class="mwb-form-group mwb-mbfw-<?php echo esc_attr( $mbfw_component['type'] ); ?>">
@@ -851,18 +870,42 @@ class Mwb_Bookings_For_Woocommerce {
 									<label for="<?php echo esc_attr( $mbfw_component['id'] ); ?>" class="mwb-form-label"><?php echo ( isset( $mbfw_component['title'] ) ? esc_html( $mbfw_component['title'] ) : '' ); ?></label>
 								</div>
 								<div class="mwb-form-group__control">
-									<label>
-										<input 
-										class="<?php echo ( isset( $mbfw_component['class'] ) ? esc_attr( $mbfw_component['class'] ) : '' ); ?>" 
+									<div class="wps-field-inline wps-time-row">
+										<input
+										class="wps-time-input <?php echo ( isset( $mbfw_component['class'] ) ? esc_attr( $mbfw_component['class'] ) : '' ); ?>"
 										name="<?php echo ( isset( $mbfw_component['name'] ) ? esc_html( $mbfw_component['name'] ) : esc_html( $mbfw_component['id'] ) ); ?>"
 										id="<?php echo esc_attr( $mbfw_component['id'] ); ?>"
 										type="<?php echo esc_attr( ( 'date' === $mbfw_component['type'] || 'time' === $mbfw_component['type'] ) ? 'text' : $mbfw_component['type'] ); ?>"
 										value="<?php echo ( isset( $mbfw_component['value'] ) ? esc_attr( $mbfw_component['value'] ) : '' ); ?>"
 										autocomplete="off"
 										>
-									</label>
-									<div class="mdc-text-field-helper-line">
-										<div class="mdc-text-field-helper-text--persistent mwb-helper-text" id="" aria-hidden="true"><?php echo ( isset( $mbfw_component['description'] ) ? esc_attr( $mbfw_component['description'] ) : '' ); ?></div>
+										<?php if ( ! empty( $mbfw_component['description'] ) ) { ?>
+											<span class="wps-helper-text wps-time-description"><?php echo esc_html( $mbfw_component['description'] ); ?></span>
+										<?php } ?>
+									</div>
+								</div>
+							</div>
+							<?php
+							break;
+
+						case 'file':
+							?>
+							<div class="mwb-form-group mwb-mbfw-<?php echo esc_attr( $mbfw_component['type'] ); ?>">
+								<div class="mwb-form-group__label">
+									<label for="<?php echo esc_attr( $mbfw_component['id'] ); ?>" class="mwb-form-label"><?php echo ( isset( $mbfw_component['title'] ) ? esc_html( $mbfw_component['title'] ) : '' ); ?></label>
+								</div>
+								<div class="mwb-form-group__control">
+									<div class="wps-field-inline">
+										<input
+										class="<?php echo ( isset( $mbfw_component['class'] ) ? esc_attr( $mbfw_component['class'] ) : '' ); ?>"
+										name="<?php echo ( isset( $mbfw_component['name'] ) ? esc_html( $mbfw_component['name'] ) : esc_html( $mbfw_component['id'] ) ); ?>"
+										id="<?php echo esc_attr( $mbfw_component['id'] ); ?>"
+										type="file"
+										autocomplete="off"
+										>
+										<?php if ( ! empty( $mbfw_component['description'] ) ) { ?>
+											<span class="wps-helper-text"><?php echo esc_html( $mbfw_component['description'] ); ?></span>
+										<?php } ?>
 									</div>
 								</div>
 							</div>

--- a/public/class-mwb-bookings-for-woocommerce-public.php
+++ b/public/class-mwb-bookings-for-woocommerce-public.php
@@ -657,6 +657,9 @@ class Mwb_Bookings_For_Woocommerce_Public {
 		 * @since 1.0.0
 		 */
 		apply_filters( 'mwb_mbfw_is_booking_available_filter', $this->mwb_mbfw_is_enable_booking() );
+		if (  'yes' !== get_option( 'mwb_mbfw_is_booking_enable' ) ) {
+			$is_booking_available = false;
+		}
 		if ( $is_booking_available ) {
 			/**
 			 * Template for Booking Product Type.


### PR DESCRIPTION
## Task Link
WPS-6824

## Summary
Full visual redesign of the WooCommerce Bookings plugin backend settings pages. Replaced Material Design Components (MDC) HTML markup in the settings field template with a new WPS design system using custom `wps-*` BEM-style classes. Restyled the admin header, form groups, and all field types (toggle, checkbox, select, text, color, time/date, file).

## Changes Made
- Replaced MDC switch/checkbox/select/text-field markup with `wps-toggle`, `wps-checkbox`, `wps-select-wrap`, `wps-text-input` components
- Added dedicated `color` case with hex display and color badge UI
- Split `file` into its own `case` (previously merged with `date`/`time`)
- Rewrote `admin/css/mwb-admin.css`: dark `#1e1245` header, card-style form rows, new component CSS
- Changed admin CSS enqueue from `.min.css` to `.css` with `filemtime()` versioning
- Changed admin JS registration to use `filemtime()` for cache-busting
- Added `talk_to_expert_nonce` to `mbfw_admin_param` JS object
- Added `wps-daily-time-pill` class to daily start/end time fields
- Updated admin dashboard and overview partials for new header/nav design

## Testing
- Tested locally: Yes
- Edge cases covered:
  - Toggle, checkbox, and radio fields save and reload correctly
  - Multiselect saves multiple values correctly
  - Color picker updates hex display on input change
  - Fields with empty description omit helper text span

## Screenshots / Demo (if applicable)

## Checklist
- [x] Code reviewed by self
- [x] No unnecessary code
- [x] Proper naming conventions
