### PR TITLE
feature/WSJ-18404-add-booking-limit-and-weekly-off-in-global-calendar

### DIFF
--- a/admin/class-mwb-bookings-for-woocommerce-admin.php
+++ b/admin/class-mwb-bookings-for-woocommerce-admin.php
@@ -92,6 +92,8 @@ class Mwb_Bookings_For_Woocommerce_Admin {
 
 		if ( 'wps_global_booking' === $post_type ) {
 			wp_enqueue_style( 'flatpickercss', MWB_BOOKINGS_FOR_WOOCOMMERCE_DIR_URL . 'package/lib/flatpickr/dist/flatpickr.min.css', array(), $this->version, 'all' );
+			wp_enqueue_style( 'mwb-mbfw-select2-css', MWB_BOOKINGS_FOR_WOOCOMMERCE_DIR_URL . 'package/lib/select-2/mwb-bookings-for-woocommerce-select2.css', array(), $this->version, 'all' );
+			wp_enqueue_style( 'wps-global-booking-admin-css', MWB_BOOKINGS_FOR_WOOCOMMERCE_DIR_URL . 'admin/css/wps-global-booking-admin.css', array( 'mwb-mbfw-select2-css' ), filemtime( MWB_BOOKINGS_FOR_WOOCOMMERCE_DIR_PATH . 'admin/css/wps-global-booking-admin.css' ), 'all' );
 		}
 		if ( 'wps_dynamic_form' === $post_type ) {
 			wp_enqueue_style( 'wps_global_booking_form_design', MWB_BOOKINGS_FOR_WOOCOMMERCE_DIR_URL . 'admin/css/wps-global-booking-form-design.min.css', array(), $this->version, 'all' );
@@ -167,8 +169,9 @@ class Mwb_Bookings_For_Woocommerce_Admin {
 		if ( 'wps_global_booking' === $post_type ) {
 
 			wp_enqueue_script( 'flatpicker_js', MWB_BOOKINGS_FOR_WOOCOMMERCE_DIR_URL . 'package/lib/flatpickr/dist/flatpickr.min.js', array( 'jquery' ), $this->version, true );
+			wp_enqueue_script( 'mwb-mbfw-select2', MWB_BOOKINGS_FOR_WOOCOMMERCE_DIR_URL . 'package/lib/select-2/mwb-bookings-for-woocommerce-select2.js', array( 'jquery' ), $this->version, true );
 
-			wp_enqueue_script( 'mwb-mbfw-admin-global-calendar-custom-js', MWB_BOOKINGS_FOR_WOOCOMMERCE_DIR_URL . 'admin/js/mwb-admin-global-calendar-custom.js', array( 'jquery', 'flatpicker_js' ), $this->version, true );
+			wp_enqueue_script( 'mwb-mbfw-admin-global-calendar-custom-js', MWB_BOOKINGS_FOR_WOOCOMMERCE_DIR_URL . 'admin/js/mwb-admin-global-calendar-custom.js', array( 'jquery', 'flatpicker_js', 'mwb-mbfw-select2' ), $this->version, true );
 			global $post;
 			if ( isset( $post ) && is_object( $post ) ) {
 				$available_days     = get_post_meta( $post->ID, '_available_days', true ) ? get_post_meta( $post->ID, '_available_days', true ) : array();
@@ -2831,6 +2834,23 @@ class Mwb_Bookings_For_Woocommerce_Admin {
 				intval( $_POST['wps_booking_limit_per_date'] )
 			);
 		}
+
+		$enable_order_limit = isset( $_POST['wps_enable_booking_limit_per_order'] ) ? '1' : '0';
+		update_post_meta( $post_id, '_wps_enable_booking_limit_per_order', $enable_order_limit );
+
+		if ( '1' === $enable_order_limit && isset( $_POST['wps_booking_limit_per_order'] ) ) {
+			update_post_meta(
+				$post_id,
+				'_wps_booking_limit_per_order',
+				intval( $_POST['wps_booking_limit_per_order'] )
+			);
+		}
+
+		$allowed_days    = array( 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday' );
+		$weekly_off_days = isset( $_POST['wps_weekly_off_days'] ) && is_array( $_POST['wps_weekly_off_days'] )
+			? array_intersect( array_map( 'sanitize_key', wp_unslash( $_POST['wps_weekly_off_days'] ) ), $allowed_days )
+			: array();
+		update_post_meta( $post_id, '_wps_weekly_off_days', array_values( $weekly_off_days ) );
 	}
 
 	/**
@@ -3110,12 +3130,25 @@ class Mwb_Bookings_For_Woocommerce_Admin {
 
 		wp_nonce_field( 'wps_global_booking_global_limit_nonce', 'wps_global_booking_global_limit_nonce_field' );
 
-		$limit = get_post_meta( $post->ID, '_wps_booking_limit_per_date', true );
+		$limit              = get_post_meta( $post->ID, '_wps_booking_limit_per_date', true );
+		$order_limit        = get_post_meta( $post->ID, '_wps_booking_limit_per_order', true );
+		$enable_order_limit = get_post_meta( $post->ID, '_wps_enable_booking_limit_per_order', true );
+		$weekly_off_days    = get_post_meta( $post->ID, '_wps_weekly_off_days', true );
+		$weekly_off_days    = is_array( $weekly_off_days ) ? $weekly_off_days : array();
+		$all_days           = array(
+			'monday'    => __( 'Monday', 'mwb-bookings-for-woocommerce' ),
+			'tuesday'   => __( 'Tuesday', 'mwb-bookings-for-woocommerce' ),
+			'wednesday' => __( 'Wednesday', 'mwb-bookings-for-woocommerce' ),
+			'thursday'  => __( 'Thursday', 'mwb-bookings-for-woocommerce' ),
+			'friday'    => __( 'Friday', 'mwb-bookings-for-woocommerce' ),
+			'saturday'  => __( 'Saturday', 'mwb-bookings-for-woocommerce' ),
+			'sunday'    => __( 'Sunday', 'mwb-bookings-for-woocommerce' ),
+		);
 		?>
 
 		<label for="wps_booking_limit_per_date"><strong><?php echo esc_html__( 'Maximum Bookings Per Date', 'mwb-bookings-for-woocommerce' ); ?></strong></label>
-		<input 
-			type="number" 
+		<input
+			type="number"
 			id="wps_booking_limit_per_date"
 			name="wps_booking_limit_per_date"
 			value="<?php echo esc_attr( $limit ); ?>"
@@ -3123,6 +3156,53 @@ class Mwb_Bookings_For_Woocommerce_Admin {
 			style="width:100%; margin-top:8px;"
 		>
 		<p class="description"><?php echo esc_html__('This limit will apply to every date.','mwb-bookings-for-woocommerce'); ?></p>
+
+		<p style="margin-top:12px;">
+			<label>
+				<input
+					type="checkbox"
+					id="wps_enable_booking_limit_per_order"
+					name="wps_enable_booking_limit_per_order"
+					value="1"
+					<?php checked( '1', $enable_order_limit ); ?>
+				>
+				<strong><?php echo esc_html__( 'Enable Booking Limit Per Order', 'mwb-bookings-for-woocommerce' ); ?></strong>
+			</label>
+		</p>
+
+		<div id="wps_booking_limit_per_order_wrap" style="<?php echo $enable_order_limit ? '' : 'display:none;'; ?>">
+			<label for="wps_booking_limit_per_order"><strong><?php echo esc_html__( 'Maximum Bookings Per Order', 'mwb-bookings-for-woocommerce' ); ?></strong></label>
+			<input
+				type="number"
+				id="wps_booking_limit_per_order"
+				name="wps_booking_limit_per_order"
+				value="<?php echo esc_attr( $order_limit ); ?>"
+				min="1"
+				style="width:100%; margin-top:8px;"
+			>
+			<p class="description"><?php echo esc_html__('This limit will apply to every order, which means that maximum four dates can be added at a time.','mwb-bookings-for-woocommerce'); ?></p>
+		</div>
+
+		<p style="margin-top:16px;">
+			<label for="wps_weekly_off_days"><strong><?php echo esc_html__( 'Weekly Off', 'mwb-bookings-for-woocommerce' ); ?></strong></label>
+			<span class="description" style="display:block; margin-top:4px;"><?php echo esc_html__( 'Select the days of the week that are unavailable for booking.', 'mwb-bookings-for-woocommerce' ); ?></span>
+		</p>
+		<select
+			id="wps_weekly_off_days"
+			name="wps_weekly_off_days[]"
+			multiple="multiple"
+			style="width:100%; margin-top:4px;"
+			size="7"
+		>
+			<?php foreach ( $all_days as $day_key => $day_label ) : ?>
+				<option
+					value="<?php echo esc_attr( $day_key ); ?>"
+					<?php selected( in_array( $day_key, $weekly_off_days, true ), true ); ?>
+				>
+					<?php echo esc_html( $day_label ); ?>
+				</option>
+			<?php endforeach; ?>
+		</select>
 
 		<?php
 	}

--- a/admin/css/mwb-admin.css
+++ b/admin/css/mwb-admin.css
@@ -3415,3 +3415,4 @@ body.mbfw-expert-modal-open {
     grid-template-columns: 1fr;
   }
 }
+

--- a/admin/css/wps-global-booking-admin.css
+++ b/admin/css/wps-global-booking-admin.css
@@ -1,0 +1,54 @@
+/* Styles for the wps_global_booking CPT edit screen */
+
+/* Weekly Off Select2 — match height and tag size of adjacent number inputs */
+#wps_weekly_off_days + .select2-container .select2-selection--multiple {
+	min-height: 28px;
+	height: auto;
+	box-sizing: border-box;
+	display: flex;
+	align-items: center;
+}
+
+#wps_weekly_off_days + .select2-container .select2-selection__rendered {
+	display: flex;
+	align-items: center;
+	flex-wrap: wrap;
+	padding: 2px 6px;
+	gap: 4px;
+	width: 100%;
+}
+
+#wps_weekly_off_days + .select2-container .select2-selection__choice {
+	font-size: 13px;
+	padding: 3px 8px;
+	line-height: 1.5;
+	margin: 0;
+	display: flex;
+	align-items: center;
+	flex-direction: row;
+}
+
+#wps_weekly_off_days + .select2-container .select2-selection__choice__display {
+	order: 1;
+}
+
+#wps_weekly_off_days + .select2-container .select2-selection__choice__remove {
+	order: 2;
+	margin-left: 5px;
+	margin-right: 0;
+}
+
+#wps_weekly_off_days + .select2-container .select2-search--inline {
+	margin: 0;
+}
+
+#wps_weekly_off_days + .select2-container .select2-search__field {
+	padding-left: 8px;
+}
+
+#wps_weekly_off_days + .select2-container .select2-selection__clear {
+	order: 99;
+	margin-left: auto;
+	margin-right: 6px;
+	float: none;
+}

--- a/admin/js/mwb-admin-global-calendar-custom.js
+++ b/admin/js/mwb-admin-global-calendar-custom.js
@@ -80,13 +80,28 @@ jQuery(function ($) {
             $field.on('keypress', function(e){
 
                 // Block minus, plus, E/e (exponential), decimal
-                if (e.key === '-' || 
-                    e.key === '+' || 
-                    e.key === 'e' || 
-                    e.key === 'E' || 
+                if (e.key === '-' ||
+                    e.key === '+' ||
+                    e.key === 'e' ||
+                    e.key === 'E' ||
                     e.key === '.' ) {
                     e.preventDefault();
                 }
+            });
+
+            // Toggle Maximum Bookings Per Order field visibility
+            var $orderLimitCheckbox = $('#wps_enable_booking_limit_per_order');
+            var $orderLimitWrap     = $('#wps_booking_limit_per_order_wrap');
+
+            $orderLimitCheckbox.on('change', function() {
+                $orderLimitWrap.toggle( this.checked );
+            });
+
+            // Initialise Select2 on Weekly Off multi-select
+            $('#wps_weekly_off_days').select2({
+                placeholder: 'Select days',
+                allowClear: true,
+                width: '100%',
             });
 	});
 

--- a/common/class-mwb-bookings-for-woocommerce-common.php
+++ b/common/class-mwb-bookings-for-woocommerce-common.php
@@ -1678,7 +1678,7 @@ class Mwb_Bookings_For_Woocommerce_Common {
 		$min = ( '' === $min ) ? null : (int) $min;
 		$max = ( '' === $max || 0 === (int) $max ) ? null : (int) $max;
 
-		if ( null !== $min && $qty < $min ) {
+		if ( $min !== null && $qty < $min ) {
 			wp_send_json_error( array(
 				/* translators: %d: minimum allowed quantity. */
 				'message' => sprintf( __( 'Minimum allowed quantity is %d.', 'mwb-bookings-for-woocommerce' ), $min ),

--- a/public/class-mwb-bookings-for-woocommerce-public.php
+++ b/public/class-mwb-bookings-for-woocommerce-public.php
@@ -562,6 +562,26 @@ class Mwb_Bookings_For_Woocommerce_Public {
 				$status_id    = 'booking-status-' . esc_attr($post_id);
 				$events = [];
 
+				$enable_order_limit = get_post_meta( $post_id, '_wps_enable_booking_limit_per_order', true );
+				$order_limit        = intval( get_post_meta( $post_id, '_wps_booking_limit_per_order', true ) );
+				$weekly_off_days    = get_post_meta( $post_id, '_wps_weekly_off_days', true );
+				$weekly_off_days    = is_array( $weekly_off_days ) ? $weekly_off_days : array();
+
+				// Filter out dates that fall on a weekly off day.
+				$is_weekly_off = function( $date ) use ( $weekly_off_days ) {
+					if ( empty( $weekly_off_days ) ) {
+						return false;
+					}
+					return in_array( strtolower( date( 'l', strtotime( $date ) ) ), $weekly_off_days, true );
+				};
+
+				$available_days   = array_values( array_filter( $available_days, function( $date ) use ( $is_weekly_off ) {
+					return ! $is_weekly_off( $date );
+				} ) );
+				$unavailable_days = array_values( array_filter( $unavailable_days, function( $date ) use ( $is_weekly_off ) {
+					return ! $is_weekly_off( $date );
+				} ) );
+
 				$available_days = array_diff($available_days, $unavailable_days);
 
 				// Available days (clickable).
@@ -587,22 +607,49 @@ class Mwb_Bookings_For_Woocommerce_Public {
 
 				$form_heading_color = get_post_meta($selected_form, '_form_heading_color', true) ? get_post_meta($selected_form, '_form_heading_color', true): '#00aaff';
 
+				// Map day names to JS getDay() values (0=Sunday … 6=Saturday).
+				$day_name_to_index = array(
+					'sunday'    => 0,
+					'monday'    => 1,
+					'tuesday'   => 2,
+					'wednesday' => 3,
+					'thursday'  => 4,
+					'friday'    => 5,
+					'saturday'  => 6,
+				);
+				$weekly_off_indexes = array_values(
+					array_map(
+						function( $day ) use ( $day_name_to_index ) {
+							return $day_name_to_index[ $day ];
+						},
+						array_filter( $weekly_off_days, function( $day ) use ( $day_name_to_index ) {
+							return isset( $day_name_to_index[ $day ] );
+						} )
+					)
+				);
+
 				wp_localize_script(
 					'booking-calendar-js', 'bookingCalendarData', [
-					'postId'           => ($post_id),
-					'containerId'      => $container_id,
-					'statusId'         => $status_id,
-					'events'           => $events,
-					'availableDates'   => $available_days,
-					'unavailableDates' => $unavailable_days,
-					'baseUrl'          => esc_url(site_url('/')),
-					'defaultPrice'     => $default_price,
-					'addToCartNonce'   => wp_create_nonce( 'mwb_booking_add_to_cart' ),
-					'form_color' 	  	=> $form_heading_color,
-					'required_msg'   => __('required', 'mwb-bookings-for-woocommerce'),
-					'date_select_msg'   => __('Please select at least one date to book.', 'mwb-bookings-for-woocommerce'),
-					'passed_dates_msg' => __('You cannot book past dates.', 'mwb-bookings-for-woocommerce'),
-					'unavailable_msg' => __( 'This date is not available for booking.', 'mwb-bookings-for-woocommerce'),
+					'postId'              => ($post_id),
+					'containerId'         => $container_id,
+					'statusId'            => $status_id,
+					'events'              => $events,
+					'availableDates'      => $available_days,
+					'unavailableDates'    => $unavailable_days,
+					'baseUrl'             => esc_url(site_url('/')),
+					'defaultPrice'        => $default_price,
+					'addToCartNonce'      => wp_create_nonce( 'mwb_booking_add_to_cart' ),
+					'form_color'          => $form_heading_color,
+					'required_msg'        => __('required', 'mwb-bookings-for-woocommerce'),
+					'date_select_msg'     => __('Please select at least one date to book.', 'mwb-bookings-for-woocommerce'),
+					'passed_dates_msg'    => __('You cannot book past dates.', 'mwb-bookings-for-woocommerce'),
+					'unavailable_msg'     => __( 'This date is not available for booking.', 'mwb-bookings-for-woocommerce'),
+					'orderLimitEnabled'   => ( '1' === $enable_order_limit ),
+					'orderLimit'          => $order_limit,
+					/* translators: %d: maximum number of dates allowed per order */
+					'order_limit_msg'     => sprintf( __( 'You can only select up to %d date(s) per order.', 'mwb-bookings-for-woocommerce' ), $order_limit ),
+					'weeklyOffDays'       => $weekly_off_indexes,
+					'weekly_off_msg'      => __( 'This day is not available for booking.', 'mwb-bookings-for-woocommerce' ),
 				]);
 			}
 		}

--- a/public/js/mwb-global-booking-shortcode.js
+++ b/public/js/mwb-global-booking-shortcode.js
@@ -12,6 +12,7 @@ document.addEventListener('DOMContentLoaded', function () {
     const defaultPrice = bookingCalendarData.defaultPrice;
     const required = bookingCalendarData.required_msg;
     const dateSelectMsg = bookingCalendarData.date_select_msg;
+    const weeklyOffDays = bookingCalendarData.weeklyOffDays || [];
 
     today.setHours(0, 0, 0, 0);
 
@@ -34,6 +35,14 @@ document.addEventListener('DOMContentLoaded', function () {
                 arg.el.style.cursor = 'not-allowed';
                 arg.el.classList.add('fc-disabled-date');
             }
+
+            // Disable weekly off days
+            if (weeklyOffDays.includes(cellDate.getDay())) {
+                arg.el.style.backgroundColor = '#f0f0f0';
+                arg.el.style.pointerEvents = 'none';
+                arg.el.style.cursor = 'not-allowed';
+                arg.el.classList.add('fc-weekly-off');
+            }
         },
 
         dateClick: function(info) {
@@ -42,6 +51,12 @@ document.addEventListener('DOMContentLoaded', function () {
 
             if (clickedDate < today) {
                 alert(bookingCalendarData.passed_dates_msg);
+                return;
+            }
+
+            // Block weekly off days
+            if (weeklyOffDays.includes(clickedDate.getDay())) {
+                alert(bookingCalendarData.weekly_off_msg);
                 return;
             }
 
@@ -66,6 +81,15 @@ document.addEventListener('DOMContentLoaded', function () {
                 selectedDates = selectedDates.filter(d => d !== clickedDateStr);
                 info.dayEl.style.backgroundColor = ''; // reset highlight
             } else {
+                // Enforce per-order booking limit if enabled
+                if (
+                    bookingCalendarData.orderLimitEnabled &&
+                    bookingCalendarData.orderLimit > 0 &&
+                    selectedDates.length >= bookingCalendarData.orderLimit
+                ) {
+                    alert(bookingCalendarData.order_limit_msg);
+                    return;
+                }
                 selectedDates.push(clickedDateStr);
                 info.dayEl.style.backgroundColor = '#90EE90'; // highlight selected
             }


### PR DESCRIPTION
## Task Link
WSJ-18404

## Summary
Adds two new settings to the global booking calendar CPT:
1. **Booking Limit Per Order** — optional checkbox + number field that caps how many dates a customer can select in one order.
2. **Weekly Off** — Select2 multi-select for marking specific weekdays as unavailable for booking globally.


## Changes Made
- `admin/class-mwb-bookings-for-woocommerce-admin.php` — enqueue Select2 CSS/JS on global booking edit screen; add "Enable Booking Limit Per Order" checkbox + number input and "Weekly Off" Select2 multi-select to meta box; save `_wps_enable_booking_limit_per_order`, `_wps_booking_limit_per_order`, `_wps_weekly_off_days` post meta
- `admin/js/mwb-admin-global-calendar-custom.js` — toggle order limit field visibility on checkbox change; initialise Select2 on weekly off select
- `admin/css/wps-global-booking-admin.css` (new) — admin styles for new fields
- `common/class-mwb-bookings-for-woocommerce-common.php` — minor code style fix
- `public/class-mwb-bookings-for-woocommerce-public.php` — read new meta, filter available/unavailable days by weekly off days (PHP-side), pass `weeklyOffDays`, `orderLimitEnabled`, `orderLimit`, and translated messages to JS via `wp_localize_script`
- `public/js/mwb-global-booking-shortcode.js` — grey out weekly off day cells in FullCalendar, block clicks on those days with alert, enforce per-order date limit before adding a date to selection

## Testing
- Tested locally: Yes
- Edge cases covered:
  - No weekly off days — no regression, calendar unchanged
  - All days as weekly off — all dates blocked
  - Order limit = 1 — only one date selectable
  - Order limit disabled — no cap applied
  - Invalid POST values for weekly off days — sanitized via `array_intersect` with allowlist

## Screenshots / Demo (if applicable)

## Checklist
- [ ] Code reviewed by self
- [ ] No unnecessary code
- [ ] Proper naming conventions
