### PR TITLE
fix/WPS-7404-date-format-mm-dd-yyyy-conflict-with-flatpickr

### DIFF
--- a/common/class-mwb-bookings-for-woocommerce-common.php
+++ b/common/class-mwb-bookings-for-woocommerce-common.php
@@ -362,10 +362,14 @@ class Mwb_Bookings_For_Woocommerce_Common {
 
 						$date_time_from = array_key_exists( 'single_cal_date_time_from', $custom_cart_data ) ? sanitize_text_field( wp_unslash( $custom_cart_data['single_cal_date_time_from'] ) ) : '';
 						$date_time_to   = array_key_exists( 'single_cal_date_time_to', $custom_cart_data ) ? sanitize_text_field( wp_unslash( $custom_cart_data['single_cal_date_time_to'] ) ) : '';
-						if('d/m/Y' == wc_date_format()){
-
-							$date_time_from         = str_replace('/', '-', $date_time_from);// custom.
-							$date_time_to           = str_replace('/', '-', $date_time_to);// custom.
+						if ( 'd/m/Y' === wc_date_format() ) {
+							// DD/MM/YYYY → DD-MM-YYYY so strtotime() parses day-first correctly.
+							$date_time_from = str_replace( '/', '-', $date_time_from );
+							$date_time_to   = str_replace( '/', '-', $date_time_to );
+						} elseif ( 'm/d/Y' === wc_date_format() ) {
+							// MM/DD/YYYY: ensure slashes so strtotime() reads it as month-first.
+							$date_time_from = preg_replace( '/^(\d{2})-(\d{2})-(\d{4})/', '$1/$2/$3', $date_time_from );
+							$date_time_to   = preg_replace( '/^(\d{2})-(\d{2})-(\d{4})/', '$1/$2/$3', $date_time_to );
 						}
 						$from_timestamp = strtotime( $date_time_from );
 						$to_timestamp   = strtotime( $date_time_to );
@@ -381,13 +385,16 @@ class Mwb_Bookings_For_Woocommerce_Common {
 				} else {
 
 					if ( 'day' === wps_booking_get_meta_data( $product_id, 'mwb_mbfw_booking_unit', true ) ) {
-						$date_from         = array_key_exists( 'date_time_from', $custom_cart_data ) ? sanitize_text_field( wp_unslash( $custom_cart_data['date_time_from'] ) ) : '';
-						$date_to           = array_key_exists( 'date_time_to', $custom_cart_data ) ? sanitize_text_field( wp_unslash( $custom_cart_data['date_time_to'] ) ) : '';
-
-						if('d/m/Y' == wc_date_format()){
-
-							$date_from         = str_replace('/', '-', $date_from);// custom.
-							$date_to           = str_replace('/', '-', $date_to);// custom.
+						$date_from = array_key_exists( 'date_time_from', $custom_cart_data ) ? sanitize_text_field( wp_unslash( $custom_cart_data['date_time_from'] ) ) : '';
+						$date_to   = array_key_exists( 'date_time_to', $custom_cart_data ) ? sanitize_text_field( wp_unslash( $custom_cart_data['date_time_to'] ) ) : '';
+						if ( 'd/m/Y' === wc_date_format() ) {
+							// DD/MM/YYYY → DD-MM-YYYY so strtotime() parses day-first correctly.
+							$date_from = str_replace( '/', '-', $date_from );
+							$date_to   = str_replace( '/', '-', $date_to );
+						} elseif ( 'm/d/Y' === wc_date_format() ) {
+							// MM/DD/YYYY: ensure slashes so strtotime() reads it as month-first.
+							$date_from = preg_replace( '/^(\d{2})-(\d{2})-(\d{4})/', '$1/$2/$3', $date_from );
+							$date_to   = preg_replace( '/^(\d{2})-(\d{2})-(\d{4})/', '$1/$2/$3', $date_to );
 						}
 						$date_from         = gmdate( 'd-m-Y', strtotime( $date_from ) );
 						$date_to           = gmdate( 'd-m-Y', strtotime( $date_to ) );
@@ -402,10 +409,14 @@ class Mwb_Bookings_For_Woocommerce_Common {
 					} elseif ( 'hour' === wps_booking_get_meta_data( $product_id, 'mwb_mbfw_booking_unit', true ) ) {
 						$date_time_from = array_key_exists( 'date_time_from', $custom_cart_data ) ? sanitize_text_field( wp_unslash( $custom_cart_data['date_time_from'] ) ) : '';
 						$date_time_to   = array_key_exists( 'date_time_to', $custom_cart_data ) ? sanitize_text_field( wp_unslash( $custom_cart_data['date_time_to'] ) ) : '';
-						if('d/m/Y' == wc_date_format()){
-
-							$date_time_from         = str_replace('/', '-', $date_time_from);// custom.
-							$date_time_to           = str_replace('/', '-', $date_time_to);// custom.
+						if ( 'd/m/Y' === wc_date_format() ) {
+							// DD/MM/YYYY → DD-MM-YYYY so strtotime() parses day-first correctly.
+							$date_time_from = str_replace( '/', '-', $date_time_from );
+							$date_time_to   = str_replace( '/', '-', $date_time_to );
+						} elseif ( 'm/d/Y' === wc_date_format() ) {
+							// MM/DD/YYYY: ensure slashes so strtotime() reads it as month-first.
+							$date_time_from = preg_replace( '/^(\d{2})-(\d{2})-(\d{4})/', '$1/$2/$3', $date_time_from );
+							$date_time_to   = preg_replace( '/^(\d{2})-(\d{2})-(\d{4})/', '$1/$2/$3', $date_time_to );
 						}
 						$from_timestamp = strtotime( $date_time_from );
 						$to_timestamp   = strtotime( $date_time_to );

--- a/public/class-mwb-bookings-for-woocommerce-public.php
+++ b/public/class-mwb-bookings-for-woocommerce-public.php
@@ -455,6 +455,7 @@ class Mwb_Bookings_For_Woocommerce_Public {
 				'today_date_check'             => $today_date_check,
 				'single_unavailable_dates'     => $single_unavailable_dates,
 				'date_format'                  => get_option( 'date_format' ),
+				'flatpickr_date_format'        => wc_date_format(),
 				'single_unavailable_prices'    => $single_unavailable_prices,
 				'wps_single_dates_temp'        => $wps_single_dates_temp,
 				'wps_single_dates_temp_dual'   => $wps_single_dates_temp_dual,
@@ -984,12 +985,21 @@ class Mwb_Bookings_For_Woocommerce_Public {
 				}
 			}
 
+			// Normalize d/m/Y POST dates (slash-separated DD/MM/YYYY) before strtotime() since
+			// PHP misreads them as m/d/Y. Convert to DD-MM-YYYY which strtotime handles correctly.
+			$wps_raw_from = array_key_exists( 'mwb_mbfw_booking_from_time', $_POST ) ? str_replace( array( 'ДП', 'ПП' ), array( 'AM', 'PM' ), sanitize_text_field( wp_unslash( $_POST['mwb_mbfw_booking_from_time'] ) ) ) : '';
+			$wps_raw_to   = array_key_exists( 'mwb_mbfw_booking_to_time', $_POST ) ? str_replace( array( 'ДП', 'ПП' ), array( 'AM', 'PM' ), sanitize_text_field( wp_unslash( $_POST['mwb_mbfw_booking_to_time'] ) ) ) : '';
+			if ( 'd/m/Y' === wc_date_format() ) {
+				$wps_raw_from = preg_replace( '/^(\d{2})\/(\d{2})\/(\d{4})/', '$1-$2-$3', $wps_raw_from );
+				$wps_raw_to   = preg_replace( '/^(\d{2})\/(\d{2})\/(\d{4})/', '$1-$2-$3', $wps_raw_to );
+			}
+
 			$custom_data = array(
 				'people_number'             => array_key_exists( 'mwb_mbfw_people_number', $_POST ) ? sanitize_text_field( wp_unslash( $_POST['mwb_mbfw_people_number'] ) ) : '',
 				'service_option'            => array_key_exists( 'mwb_mbfw_service_option_checkbox', $_POST ) ? map_deep( wp_unslash( $_POST['mwb_mbfw_service_option_checkbox'] ), 'sanitize_text_field' ) : array(),
 				'service_quantity'          => array_key_exists( 'mwb_mbfw_service_quantity', $_POST ) ? map_deep( wp_unslash( $_POST['mwb_mbfw_service_quantity'] ), 'sanitize_text_field' ) : array(),
-				'date_time_from'            => array_key_exists( 'mwb_mbfw_booking_from_time', $_POST ) ? gmdate( $date_format, strtotime( str_replace(['ДП', 'ПП'], ['AM', 'PM'], sanitize_text_field( wp_unslash( $_POST['mwb_mbfw_booking_from_time'] ) ) ) ) ) : '',
-				'date_time_to'              => array_key_exists( 'mwb_mbfw_booking_to_time', $_POST ) ? gmdate( $date_format, strtotime( str_replace(['ДП', 'ПП'], ['AM', 'PM'], sanitize_text_field( wp_unslash( $_POST['mwb_mbfw_booking_to_time'] ) ) ) ) ) : '',
+				'date_time_from'            => ! empty( $wps_raw_from ) ? gmdate( $date_format, strtotime( $wps_raw_from ) ) : '',
+				'date_time_to'              => ! empty( $wps_raw_to ) ? gmdate( $date_format, strtotime( $wps_raw_to ) ) : '',
 				'single_cal_booking_dates'  => $single_cal_booking_dates,
 				'single_cal_date_time_from' => $date_time_from,
 				'single_cal_date_time_to'   => $date_time_to,

--- a/public/js/mwb-public.js
+++ b/public/js/mwb-public.js
@@ -108,7 +108,8 @@ jQuery(document).ready(function($){
          from_time =  'mwb-mbfw-booking-from-time';
          to_time =  'mwb-mbfw-booking-to-time';
     const time_format =('twelve_hour' == mwb_mbfw_public_obj.wps_diaplay_time_format )? false:true;
-	const date_time_format = ( 'twelve_hour' == mwb_mbfw_public_obj.wps_diaplay_time_format ) ? "d-m-Y h:i K" : "d-m-Y H:i";
+	const fp_date_fmt = mwb_mbfw_public_obj.flatpickr_date_format || 'd-m-Y';
+	const date_time_format = ( 'twelve_hour' == mwb_mbfw_public_obj.wps_diaplay_time_format ) ? fp_date_fmt + " h:i K" : fp_date_fmt + " H:i";
 
     if( is_pro_active != 'yes' ) {
 
@@ -283,13 +284,13 @@ jQuery(document).ready(function($){
 
 
             } else {
-                flatpickr('#'+from_time, {  
+                flatpickr('#'+from_time, {
                     disableMobile: true,
                     locale: {...flatpickr.l10ns[mwb_mbfw_public_obj.lang] , // Set language
                             firstDayOfWeek: mwb_mbfw_public_obj.firstDayOf_Week,  // Set first day of the week
-                        }, 
-                    dateFormat: "d-m-Y",
-                  
+                        },
+                    dateFormat: fp_date_fmt,
+
                     onDayCreate: function(dObj, dStr, fp, dayElem){
                         dObj = dayElem.dateObj;
 
@@ -321,14 +322,13 @@ jQuery(document).ready(function($){
                     
                 }); 
         
-                flatpickr('#'+to_time, {  
+                flatpickr('#'+to_time, {
                     disableMobile: true,
                     locale: {...flatpickr.l10ns[mwb_mbfw_public_obj.lang] , // Set language
                             firstDayOfWeek: mwb_mbfw_public_obj.firstDayOf_Week,  // Set first day of the week
-                        }, 
-                    dateFormat: "d-m-Y",
-                    
-                   
+                        },
+                    dateFormat: fp_date_fmt,
+
                     onDayCreate: function(dObj, dStr, fp, dayElem){
                         dObj = dayElem.dateObj;
 
@@ -524,13 +524,12 @@ jQuery(document).ready(function($){
 
             }
             else{
-                flatpickr('#'+from_time, {  
-                    
+                flatpickr('#'+from_time, {
                     disableMobile: true,
                     locale: {...flatpickr.l10ns[mwb_mbfw_public_obj.lang] , // Set language
                             firstDayOfWeek: mwb_mbfw_public_obj.firstDayOf_Week,  // Set first day of the week
-                        }, 
-                        dateFormat: "d-m-Y",
+                        },
+                    dateFormat: fp_date_fmt,
                     onDayCreate: function(dObj, dStr, fp, dayElem){
                         dObj = dayElem.dateObj;
 
@@ -560,13 +559,13 @@ jQuery(document).ready(function($){
                    
                 }); 
         
-                flatpickr('#'+to_time, {  
+                flatpickr('#'+to_time, {
                     disableMobile: true,
                     locale: {...flatpickr.l10ns[mwb_mbfw_public_obj.lang] , // Set language
                             firstDayOfWeek: mwb_mbfw_public_obj.firstDayOf_Week,  // Set first day of the week
-                        }, 
-                        dateFormat: "d-m-Y",
-                  
+                        },
+                    dateFormat: fp_date_fmt,
+
                     onDayCreate: function(dObj, dStr, fp, dayElem){
                         dObj = dayElem.dateObj;
 


### PR DESCRIPTION
## Task Link
WPS-7404

## Summary
Flatpickr date pickers were hardcoded to `d-m-Y` (DD-MM-YYYY) format in JS, ignoring the WooCommerce date format setting. Additionally, PHP date-parsing logic only handled the `d/m/Y` format and missed `m/d/Y` (US MM/DD/YYYY), causing incorrect timestamps and potentially wrong booking dates or price calculations for stores using the US date format.

## Changes Made
- `public/js/mwb-public.js`: Added `fp_date_fmt` variable reading `mwb_mbfw_public_obj.flatpickr_date_format` (with `d-m-Y` fallback); replaced 5 hardcoded `"d-m-Y"` instances with `fp_date_fmt`
- `public/class-mwb-bookings-for-woocommerce-public.php`: Added `flatpickr_date_format => wc_date_format()` to `wp_localize_script`; extracted POST date values into `$wps_raw_from`/`$wps_raw_to` with `d/m/Y` normalization before `strtotime()`
- `common/class-mwb-bookings-for-woocommerce-common.php`: Added `elseif ( 'm/d/Y' === wc_date_format() )` branches in all 3 date-parsing blocks (single-cal hourly, day unit, hour unit)

## Testing
- Tested locally: No
- Edge cases covered:
  - `d/m/Y` format: existing behaviour preserved
  - `m/d/Y` format: now correctly normalised before strtotime
  - `Y-m-d` / other formats: fall through without modification (strtotime handles natively)
  - Datetime pickers: dynamic date part + existing time suffix

## Screenshots / Demo (if applicable)
N/A

## Checklist
- [ ] Code reviewed by self
- [ ] No unnecessary code
- [ ] Proper naming conventions
